### PR TITLE
Add responsive main navbar (inline on desktop, menu dropdown on mobile)

### DIFF
--- a/src/app/nonprofit/page.tsx
+++ b/src/app/nonprofit/page.tsx
@@ -67,7 +67,7 @@ const NonprofitDashboard = () => {
     }
     const user = session.user as ExtendedUser;
     loadData(user.nonprofitId, user.productSurveyId);
-  }, [status]);
+  }, [status, session?.user, router, loadData]);
 
   if (loading) {
     return (

--- a/src/app/supplier/page.tsx
+++ b/src/app/supplier/page.tsx
@@ -52,7 +52,7 @@ const SupplierDashboard = () => {
       return;
     }
     loadSupplierData();
-  }, [status]);
+  }, [status, session?.user?.role, router, loadSupplierData]);
 
   return (
     <div className='light min-h-screen bg-gray-50'>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/lib/utils';
 type NavItem = { href: string; label: string };
 
 function buildNavItems(
-  role: false | UserRole | undefined,
+  role: false | UserRole | undefined | null,
   isAdminOrStaff: boolean,
   isOther: boolean
 ): NavItem[] {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { UserMenu } from './user-menu';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
-import { UserRole } from '../../../types/types';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,6 +18,7 @@ type NavItem = { href: string; label: string };
 
 function buildNavItems(
   role: false | UserRole | undefined | null,
+  role: false | string | null | undefined,
   isAdminOrStaff: boolean,
   isOther: boolean
 ): NavItem[] {
@@ -29,11 +29,11 @@ function buildNavItems(
     items.push({ href: '/users', label: 'Users' });
   }
 
-  if (role === UserRole.SUPPLIER) {
+  if (role === 'SUPPLIER') {
     items.push({ href: '/supplier', label: 'Supplier' });
   }
 
-  if (role === UserRole.NONPROFIT) {
+  if (role === 'NONPROFIT') {
     items.push({ href: '/nonprofit', label: 'Nonprofit' });
   }
 
@@ -60,8 +60,8 @@ export function Header() {
   const pathname = usePathname();
 
   const role = status === 'authenticated' && data?.user.role;
-  const isAdminOrStaff = role === UserRole.ADMIN || role === UserRole.STAFF;
-  const isOther = role === UserRole.OTHER;
+  const isAdminOrStaff = role === 'ADMIN' || role === 'STAFF';
+  const isOther = role === 'OTHER';
 
   const navItems = buildNavItems(role, isAdminOrStaff, isOther);
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -13,16 +13,58 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { ChevronDown } from 'lucide-react';
 import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+type NavItem = { href: string; label: string };
+
+function buildNavItems(
+  role: false | UserRole | undefined,
+  isAdminOrStaff: boolean,
+  isOther: boolean
+): NavItem[] {
+  const items: NavItem[] = [];
+
+  if (isAdminOrStaff) {
+    items.push({ href: '/admin', label: 'Admin' });
+    items.push({ href: '/users', label: 'Users' });
+  }
+
+  if (role === UserRole.SUPPLIER) {
+    items.push({ href: '/supplier', label: 'Supplier' });
+  }
+
+  if (role === UserRole.NONPROFIT) {
+    items.push({ href: '/nonprofit', label: 'Nonprofit' });
+  }
+
+  items.push(
+    { href: '/announcements', label: 'Announcements' },
+    { href: '/discussion', label: 'Discussion' },
+    { href: '/documentation', label: 'Documentation' }
+  );
+
+  if (isOther) {
+    items.push({ href: '/onboarding', label: 'Complete Profile' });
+  }
+
+  return items;
+}
+
+function isNavActive(pathname: string, href: string): boolean {
+  if (href === '/') return pathname === '/';
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
 
 export function Header() {
   const { data, status } = useSession();
   const pathname = usePathname();
 
-  const role = status === 'authenticated' && data?.user.role; // 'ADMIN', 'SUPPLIER', 'NONPROFIT', 'OTHER'
+  const role = status === 'authenticated' && data?.user.role;
   const isAdminOrStaff = role === UserRole.ADMIN || role === UserRole.STAFF;
   const isOther = role === UserRole.OTHER;
 
-  // Map routes to labels
+  const navItems = buildNavItems(role, isAdminOrStaff, isOther);
+
   const pageLabels: Record<string, string> = {
     '/admin': 'Admin',
     '/users': 'Users',
@@ -38,9 +80,9 @@ export function Header() {
   const triggerLabel = activeKey ? pageLabels[activeKey] : 'Menu';
 
   return (
-    <header className='fixed left-0 right-0 top-0 z-50 flex items-center justify-between border-b bg-background px-6 py-4'>
-      <div className='flex items-center justify-center gap-4'>
-        <Link href='/' className='flex items-center space-x-2'>
+    <header className='fixed left-0 right-0 top-0 z-50 flex items-center justify-between gap-4 border-b bg-background px-4 py-4 sm:px-6'>
+      <div className='flex min-w-0 flex-1 items-center gap-3 sm:gap-4'>
+        <Link href='/' className='flex shrink-0 items-center space-x-2'>
           <Image
             src='/c4g-logo.png'
             alt='Computing for good'
@@ -49,61 +91,41 @@ export function Header() {
           />
         </Link>
 
-        {/* Dropdown Menu visible based on roles */}
-        <DropdownMenu>
-          <DropdownMenuTrigger className='flex items-center gap-1 text-sm font-medium hover:text-primary'>
-            {triggerLabel} <ChevronDown size={14} />
-          </DropdownMenuTrigger>
+        <nav
+          aria-label='Main'
+          className='hidden min-w-0 flex-1 items-center gap-x-2 gap-y-1 overflow-x-auto md:flex lg:gap-x-4'
+        >
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'shrink-0 text-sm font-medium whitespace-nowrap transition-colors hover:text-primary',
+                isNavActive(pathname, item.href)
+                  ? 'text-primary'
+                  : 'text-muted-foreground'
+              )}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
 
-          <DropdownMenuContent className='w-48'>
-            {/* Role Based - Admin or Staff */}
-            {isAdminOrStaff && (
-              <>
-                <DropdownMenuItem asChild>
-                  <Link href='/admin'>Admin</Link>
+        <div className='md:hidden'>
+          <DropdownMenu>
+            <DropdownMenuTrigger className='flex items-center gap-1 text-sm font-medium hover:text-primary'>
+              {triggerLabel} <ChevronDown size={14} />
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent className='w-48' align='start'>
+              {navItems.map((item) => (
+                <DropdownMenuItem key={item.href} asChild>
+                  <Link href={item.href}>{item.label}</Link>
                 </DropdownMenuItem>
-
-                <DropdownMenuItem asChild>
-                  <Link href='/users'>Users</Link>
-                </DropdownMenuItem>
-              </>
-            )}
-
-            {/* Supplier Dashboard */}
-            {role === UserRole.SUPPLIER && (
-              <DropdownMenuItem asChild>
-                <Link href='/supplier'>Supplier</Link>
-              </DropdownMenuItem>
-            )}
-
-            {/* Nonprofit Dashboard */}
-            {role === UserRole.NONPROFIT && (
-              <DropdownMenuItem asChild>
-                <Link href='/nonprofit'>Nonprofit</Link>
-              </DropdownMenuItem>
-            )}
-
-            {/* Routes available for all */}
-            <DropdownMenuItem asChild>
-              <Link href='/announcements'>Announcements</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem asChild>
-              <Link href='/discussion'>Discussion</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem asChild>
-              <Link href='/documentation'>Documentation</Link>
-            </DropdownMenuItem>
-
-            {/* Prompt OTHER users to complete their profile */}
-            {isOther && (
-              <DropdownMenuItem asChild>
-                <Link href='/onboarding'>Complete Profile</Link>
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
       <UserMenu />
     </header>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,7 +17,6 @@ import { cn } from '@/lib/utils';
 type NavItem = { href: string; label: string };
 
 function buildNavItems(
-  role: false | UserRole | undefined | null,
   role: false | string | null | undefined,
   isAdminOrStaff: boolean,
   isOther: boolean


### PR DESCRIPTION
Updates the site header so primary navigation matches common desktop patterns using horizontal links while keeping a single Menu dropdown on on small viewports.
- added role-aware nav items in one place `buildNavItems` and reuse them for both layouts so desktop and mobile stay in sync
- styling the inline nav with active state (current route) and horizontal scroll as a fallback when space is tight

Can test using a mobile device or inspect element -> mobile/tablet tests on google chrome (F12) or resize browser dimensions.