### PR TITLE
Claims sort options in nonprofits page

### DIFF
--- a/src/app/api/nonprofits/route.test.ts
+++ b/src/app/api/nonprofits/route.test.ts
@@ -101,6 +101,11 @@ describe('/api/nonprofits - GET', () => {
       where: { id: nonprofitId },
       include: {
         productsClaimed: {
+          orderBy: {
+            pickupInfo: {
+              pickupDate: 'asc',
+            },
+          },
           include: {
             productType: true,
             pickupInfo: true,

--- a/src/app/api/nonprofits/route.ts
+++ b/src/app/api/nonprofits/route.ts
@@ -39,6 +39,11 @@ export async function GET(req: Request) {
       },
       include: {
         productsClaimed: {
+          orderBy: {
+            pickupInfo: {
+              pickupDate: 'asc',
+            },
+          },
           include: {
             productType: true,
             pickupInfo: true,

--- a/src/app/nonprofit/_components/ClaimsTab.tsx
+++ b/src/app/nonprofit/_components/ClaimsTab.tsx
@@ -1,7 +1,35 @@
 'use client';
+import { useMemo, useState } from 'react';
 import { ClaimConfirmationPopup } from '@/components/Nonprofit/ClaimConfirmationPopup';
 import { ClaimedItemDetailsPopup } from '@/components/Nonprofit/ClaimedItemDetailsPopup';
 import { Nonprofit, ProductInterest, ClaimedProduct } from '../_types';
+
+type ClaimsSortMode = 'pickupSoonest' | 'recentlyClaimed';
+
+function sortClaimedProducts(
+  products: ClaimedProduct[],
+  mode: ClaimsSortMode
+): ClaimedProduct[] {
+  const list = [...products];
+  const byId = (a: ClaimedProduct, b: ClaimedProduct) =>
+    a.id.localeCompare(b.id);
+
+  if (mode === 'pickupSoonest') {
+    return list.sort((a, b) => {
+      const diff =
+        new Date(a.pickupInfo.pickupDate).getTime() -
+        new Date(b.pickupInfo.pickupDate).getTime();
+      return diff !== 0 ? diff : byId(a, b);
+    });
+  }
+
+  return list.sort((a, b) => {
+    const ta = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+    const tb = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+    const diff = tb - ta;
+    return diff !== 0 ? diff : byId(a, b);
+  });
+}
 
 interface ClaimsTabProps {
   nonprofit: Nonprofit;
@@ -44,6 +72,13 @@ const ClaimsTab = ({
   setUnclaimConfirm,
   handleUnclaimProduct,
 }: ClaimsTabProps) => {
+  const [claimsSort, setClaimsSort] = useState<ClaimsSortMode>('pickupSoonest');
+
+  const sortedClaimedProducts = useMemo(
+    () => sortClaimedProducts(nonprofit.productsClaimed, claimsSort),
+    [nonprofit.productsClaimed, claimsSort]
+  );
+
   return (
     <div className='space-y-6'>
       {/* Product Interests Section */}
@@ -113,47 +148,75 @@ const ClaimsTab = ({
 
       {/* Claimed Products Section */}
       <div className='rounded-xl border border-slate-200 bg-white p-6 shadow-lg'>
-        <h2 className='mb-4 text-xl font-semibold text-slate-800'>
-          Claimed Products
-        </h2>
+        <div className='mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+          <h2 className='text-xl font-semibold text-slate-800'>
+            Claimed Products
+          </h2>
+          {nonprofit.productsClaimed.length > 0 && (
+            <div className='flex flex-wrap items-center gap-2'>
+              <label
+                htmlFor='claims-sort'
+                className='text-sm font-medium text-slate-600'
+              >
+                Sort by
+              </label>
+              <select
+                id='claims-sort'
+                value={claimsSort}
+                onChange={(e) =>
+                  setClaimsSort(e.target.value as ClaimsSortMode)
+                }
+                className='rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500'
+              >
+                <option value='pickupSoonest'>Pickup Date (Soonest)</option>
+                <option value='recentlyClaimed'>
+                  Most Recently Claimed
+                </option>
+              </select>
+            </div>
+          )}
+        </div>
         {nonprofit.productsClaimed.length > 0 ? (
           <div className='grid gap-4 md:grid-cols-2'>
-            {nonprofit.productsClaimed.map((product) => (
-              <div
-                key={product.id}
-                className='cursor-pointer rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm transition-all hover:border-blue-500 hover:shadow-md'
-                onClick={(e) => showItemDetails(e, product)}
-              >
-                <h3 className='font-semibold text-slate-800'>{product.name}</h3>
-                <div className='mt-2 space-y-1'>
-                  <p className='text-slate-700'>Quantity: {product.quantity}</p>
-                  <p className='text-slate-700'>Status: {product.status}</p>
-                  <p className='text-slate-700'>
-                    Pickup Date:{' '}
-                    {new Date(
-                      product.pickupInfo.pickupDate
-                    ).toLocaleDateString()}
-                  </p>
-                  <p className='text-slate-700'>
-                    Location: {product.pickupInfo.pickupLocation}
-                  </p>
-                </div>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setUnclaimConfirm({
-                      open: true,
-                      productId: product.id,
-                      productName: product.name,
-                      pickupDate: product.pickupInfo.pickupDate,
-                    });
-                  }}
-                  className='mt-4 rounded-md bg-red-600 px-4 py-2 text-white shadow-sm transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2'
+            {sortedClaimedProducts.map((product) => {
+              const pickupLabel = new Date(
+                product.pickupInfo.pickupDate
+              ).toLocaleDateString();
+              return (
+                <div
+                  key={product.id}
+                  className='cursor-pointer rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm transition-all hover:border-blue-500 hover:shadow-md'
+                  onClick={(e) => showItemDetails(e, product)}
                 >
-                  Unclaim Product
-                </button>
-              </div>
-            ))}
+                  <h3 className='text-lg font-bold leading-snug tracking-tight text-slate-900'>
+                    {product.name}
+                  </h3>
+                  <p className='mt-2 text-base font-semibold text-blue-900'>
+                    Pickup: {pickupLabel}
+                  </p>
+                  <div className='mt-3 space-y-1 border-t border-slate-200/80 pt-3 text-sm text-slate-600'>
+                    <p>Quantity: {product.quantity}</p>
+                    <p>Status: {product.status}</p>
+                    <p>Location: {product.pickupInfo.pickupLocation}</p>
+                  </div>
+                  <button
+                    type='button'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setUnclaimConfirm({
+                        open: true,
+                        productId: product.id,
+                        productName: product.name,
+                        pickupDate: product.pickupInfo.pickupDate,
+                      });
+                    }}
+                    className='mt-4 rounded-md bg-red-600 px-4 py-2 text-white shadow-sm transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2'
+                  >
+                    Unclaim Product
+                  </button>
+                </div>
+              );
+            })}
             {showItemDetailPopup && (
               <ClaimedItemDetailsPopup
                 showDetailsPopup={showItemDetailPopup}

--- a/src/app/nonprofit/_hooks/useClaim.ts
+++ b/src/app/nonprofit/_hooks/useClaim.ts
@@ -78,6 +78,7 @@ const useClaim = ({
                 status: claimedProduct.status,
                 productType: claimedProduct.productType,
                 pickupInfo: claimedProduct.pickupInfo,
+                updatedAt: claimedProduct.updatedAt,
               },
             ],
           };

--- a/src/app/nonprofit/_types/index.ts
+++ b/src/app/nonprofit/_types/index.ts
@@ -5,6 +5,8 @@ export interface ClaimedProduct {
   quantity: number;
   unit?: string;
   status: string;
+  /** ISO timestamp; used for “most recently claimed” sort (Prisma `updatedAt`). */
+  updatedAt?: string;
   productType: {
     id: string;
     protein: boolean;

--- a/src/app/nonprofit/page.tsx
+++ b/src/app/nonprofit/page.tsx
@@ -67,7 +67,7 @@ const NonprofitDashboard = () => {
     }
     const user = session.user as ExtendedUser;
     loadData(user.nonprofitId, user.productSurveyId);
-  }, [status]);
+  }, [status, session?.user, router, loadData]);
 
   if (loading) {
     return (

--- a/src/app/supplier/page.tsx
+++ b/src/app/supplier/page.tsx
@@ -52,7 +52,7 @@ const SupplierDashboard = () => {
       return;
     }
     loadSupplierData();
-  }, [status]);
+  }, [status, session?.user?.role, router, loadSupplierData]);
 
   return (
     <div className='light min-h-screen bg-gray-50'>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/lib/utils';
 type NavItem = { href: string; label: string };
 
 function buildNavItems(
-  role: false | UserRole | undefined,
+  role: false | UserRole | undefined | null,
   isAdminOrStaff: boolean,
   isOther: boolean
 ): NavItem[] {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { UserMenu } from './user-menu';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
-import { UserRole } from '../../../types/types';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,6 +18,7 @@ type NavItem = { href: string; label: string };
 
 function buildNavItems(
   role: false | UserRole | undefined | null,
+  role: false | string | null | undefined,
   isAdminOrStaff: boolean,
   isOther: boolean
 ): NavItem[] {
@@ -29,11 +29,11 @@ function buildNavItems(
     items.push({ href: '/users', label: 'Users' });
   }
 
-  if (role === UserRole.SUPPLIER) {
+  if (role === 'SUPPLIER') {
     items.push({ href: '/supplier', label: 'Supplier' });
   }
 
-  if (role === UserRole.NONPROFIT) {
+  if (role === 'NONPROFIT') {
     items.push({ href: '/nonprofit', label: 'Nonprofit' });
   }
 
@@ -60,8 +60,8 @@ export function Header() {
   const pathname = usePathname();
 
   const role = status === 'authenticated' && data?.user.role;
-  const isAdminOrStaff = role === UserRole.ADMIN || role === UserRole.STAFF;
-  const isOther = role === UserRole.OTHER;
+  const isAdminOrStaff = role === 'ADMIN' || role === 'STAFF';
+  const isOther = role === 'OTHER';
 
   const navItems = buildNavItems(role, isAdminOrStaff, isOther);
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -13,16 +13,58 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { ChevronDown } from 'lucide-react';
 import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+type NavItem = { href: string; label: string };
+
+function buildNavItems(
+  role: false | UserRole | undefined,
+  isAdminOrStaff: boolean,
+  isOther: boolean
+): NavItem[] {
+  const items: NavItem[] = [];
+
+  if (isAdminOrStaff) {
+    items.push({ href: '/admin', label: 'Admin' });
+    items.push({ href: '/users', label: 'Users' });
+  }
+
+  if (role === UserRole.SUPPLIER) {
+    items.push({ href: '/supplier', label: 'Supplier' });
+  }
+
+  if (role === UserRole.NONPROFIT) {
+    items.push({ href: '/nonprofit', label: 'Nonprofit' });
+  }
+
+  items.push(
+    { href: '/announcements', label: 'Announcements' },
+    { href: '/discussion', label: 'Discussion' },
+    { href: '/documentation', label: 'Documentation' }
+  );
+
+  if (isOther) {
+    items.push({ href: '/onboarding', label: 'Complete Profile' });
+  }
+
+  return items;
+}
+
+function isNavActive(pathname: string, href: string): boolean {
+  if (href === '/') return pathname === '/';
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
 
 export function Header() {
   const { data, status } = useSession();
   const pathname = usePathname();
 
-  const role = status === 'authenticated' && data?.user.role; // 'ADMIN', 'SUPPLIER', 'NONPROFIT', 'OTHER'
+  const role = status === 'authenticated' && data?.user.role;
   const isAdminOrStaff = role === UserRole.ADMIN || role === UserRole.STAFF;
   const isOther = role === UserRole.OTHER;
 
-  // Map routes to labels
+  const navItems = buildNavItems(role, isAdminOrStaff, isOther);
+
   const pageLabels: Record<string, string> = {
     '/admin': 'Admin',
     '/users': 'Users',
@@ -38,9 +80,9 @@ export function Header() {
   const triggerLabel = activeKey ? pageLabels[activeKey] : 'Menu';
 
   return (
-    <header className='fixed left-0 right-0 top-0 z-50 flex items-center justify-between border-b bg-background px-6 py-4'>
-      <div className='flex items-center justify-center gap-4'>
-        <Link href='/' className='flex items-center space-x-2'>
+    <header className='fixed left-0 right-0 top-0 z-50 flex items-center justify-between gap-4 border-b bg-background px-4 py-4 sm:px-6'>
+      <div className='flex min-w-0 flex-1 items-center gap-3 sm:gap-4'>
+        <Link href='/' className='flex shrink-0 items-center space-x-2'>
           <Image
             src='/c4g-logo.png'
             alt='Computing for good'
@@ -49,61 +91,41 @@ export function Header() {
           />
         </Link>
 
-        {/* Dropdown Menu visible based on roles */}
-        <DropdownMenu>
-          <DropdownMenuTrigger className='flex items-center gap-1 text-sm font-medium hover:text-primary'>
-            {triggerLabel} <ChevronDown size={14} />
-          </DropdownMenuTrigger>
+        <nav
+          aria-label='Main'
+          className='hidden min-w-0 flex-1 items-center gap-x-2 gap-y-1 overflow-x-auto md:flex lg:gap-x-4'
+        >
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'shrink-0 text-sm font-medium whitespace-nowrap transition-colors hover:text-primary',
+                isNavActive(pathname, item.href)
+                  ? 'text-primary'
+                  : 'text-muted-foreground'
+              )}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
 
-          <DropdownMenuContent className='w-48'>
-            {/* Role Based - Admin or Staff */}
-            {isAdminOrStaff && (
-              <>
-                <DropdownMenuItem asChild>
-                  <Link href='/admin'>Admin</Link>
+        <div className='md:hidden'>
+          <DropdownMenu>
+            <DropdownMenuTrigger className='flex items-center gap-1 text-sm font-medium hover:text-primary'>
+              {triggerLabel} <ChevronDown size={14} />
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent className='w-48' align='start'>
+              {navItems.map((item) => (
+                <DropdownMenuItem key={item.href} asChild>
+                  <Link href={item.href}>{item.label}</Link>
                 </DropdownMenuItem>
-
-                <DropdownMenuItem asChild>
-                  <Link href='/users'>Users</Link>
-                </DropdownMenuItem>
-              </>
-            )}
-
-            {/* Supplier Dashboard */}
-            {role === UserRole.SUPPLIER && (
-              <DropdownMenuItem asChild>
-                <Link href='/supplier'>Supplier</Link>
-              </DropdownMenuItem>
-            )}
-
-            {/* Nonprofit Dashboard */}
-            {role === UserRole.NONPROFIT && (
-              <DropdownMenuItem asChild>
-                <Link href='/nonprofit'>Nonprofit</Link>
-              </DropdownMenuItem>
-            )}
-
-            {/* Routes available for all */}
-            <DropdownMenuItem asChild>
-              <Link href='/announcements'>Announcements</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem asChild>
-              <Link href='/discussion'>Discussion</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem asChild>
-              <Link href='/documentation'>Documentation</Link>
-            </DropdownMenuItem>
-
-            {/* Prompt OTHER users to complete their profile */}
-            {isOther && (
-              <DropdownMenuItem asChild>
-                <Link href='/onboarding'>Complete Profile</Link>
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
       <UserMenu />
     </header>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,7 +17,6 @@ import { cn } from '@/lib/utils';
 type NavItem = { href: string; label: string };
 
 function buildNavItems(
-  role: false | UserRole | undefined | null,
   role: false | string | null | undefined,
   isAdminOrStaff: boolean,
   isOther: boolean


### PR DESCRIPTION
- Nonprofit My Claims now defaults to pickup order (soonest first) and adds a Sort by control so users can switch to most recently claimed, with clearer emphasis on the product name and pickup date

- Unclaim still uses the existing confirmation step; the nonprofits API also returns claimed products ordered by pickup date

Worked on based off of field evaluation.

<img width="1617" height="434" alt="image" src="https://github.com/user-attachments/assets/14142f24-0b44-42db-b243-7177d6632597" />
<img width="1604" height="419" alt="image" src="https://github.com/user-attachments/assets/1681b2dd-b060-41a3-92d3-ca04b6dfe2ad" />
