### PR TITLE
enhance supplier dashboard with drill-down KPIs, sortable tables

### DIFF
--- a/src/app/supplier/_components/OverviewTab.tsx
+++ b/src/app/supplier/_components/OverviewTab.tsx
@@ -1,24 +1,628 @@
 'use client';
+import { useState, useMemo } from 'react';
 import { DonutChart } from '@/components/charts/DonutChart';
 import { BarChartComponent } from '@/components/charts/BarChartComponent';
 import { AreaChartComponent } from '@/components/charts/AreaChartComponent';
 import { KPICard } from '@/components/charts/KPICard';
 import { SUPPLIER_CHART_INFO } from '@/components/charts/chart-info-text';
 import { SupplierMetrics } from '../_types';
+import { ProductRequest } from '../../../../types/types';
+import {
+  ArrowLeft,
+  Search,
+  Package,
+  Scale,
+  TrendingUp,
+  Clock,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+} from 'lucide-react';
+import { AreaChart, Area, ResponsiveContainer } from 'recharts';
+
+type TileFilter = 'all' | 'available' | 'claimed' | 'fast';
 
 interface OverviewTabProps {
   metricsData: SupplierMetrics | null;
   loadingMetrics: boolean;
+  productRequests: ProductRequest[];
 }
 
-const OverviewTab = ({ metricsData, loadingMetrics }: OverviewTabProps) => {
+function findFoodType(product: ProductRequest): string {
+  const pt = product.productType;
+  if (!pt) return 'Unknown';
+  if (pt.protein) return 'Protein';
+  if (pt.produce) return 'Produce';
+  if (pt.shelfStable) return 'Shelf Stable';
+  if (pt.shelfStableIndividualServing) return 'Individual Serving';
+  if (pt.alreadyPreparedFood) return 'Prepared Food';
+  if (pt.other) return 'Other';
+  return 'Unknown';
+}
+
+function filterProducts(
+  products: ProductRequest[],
+  filter: TileFilter
+): ProductRequest[] {
+  switch (filter) {
+    case 'available':
+      return products.filter((p) => p.status === 'AVAILABLE');
+    case 'claimed':
+      return products.filter((p) => ['RESERVED', 'PENDING'].includes(p.status));
+    case 'fast':
+      return products.filter((p) => {
+        if (!['RESERVED', 'PENDING'].includes(p.status)) return false;
+        const diffMs =
+          new Date(p.updatedAt).getTime() - new Date(p.createdAt).getTime();
+        return diffMs / (1000 * 60 * 60) <= 24;
+      });
+    default:
+      return products;
+  }
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  Protein: '#ef4444',
+  Produce: '#22c55e',
+  'Shelf Stable': '#f59e0b',
+  'Individual Serving': '#a855f7',
+  'Prepared Food': '#f97316',
+  Other: '#6b7280',
+  Unknown: '#94a3b8',
+};
+
+const FILTER_CONFIG: Record<
+  Exclude<TileFilter, 'all'>,
+  { title: string; barTitle: string; color: string }
+> = {
+  available: {
+    title: 'Available Products',
+    barTitle: 'Available Products by Type',
+    color: '#10b981',
+  },
+  claimed: {
+    title: 'Claimed Products',
+    barTitle: 'Claimed Products by Type',
+    color: '#3b82f6',
+  },
+  fast: {
+    title: 'Fast Claims (Within 24h)',
+    barTitle: 'Fast Claims by Type',
+    color: '#f59e0b',
+  },
+};
+
+function formatStatus(status: string): string {
+  return status.charAt(0) + status.slice(1).toLowerCase();
+}
+
+function formatDate(date: Date | string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+// ── Sort helpers ──
+type SortKey =
+  | 'name'
+  | 'type'
+  | 'quantity'
+  | 'status'
+  | 'posted'
+  | 'claimSpeed';
+type SortDir = 'asc' | 'desc';
+
+function getClaimHours(p: ProductRequest): number {
+  if (!['RESERVED', 'PENDING'].includes(p.status)) return Infinity;
+  return (
+    (new Date(p.updatedAt).getTime() - new Date(p.createdAt).getTime()) /
+    (1000 * 60 * 60)
+  );
+}
+
+function getClaimSpeedLabel(hours: number): string {
+  if (hours === Infinity) return '';
+  if (hours <= 24) return '< 24h';
+  if (hours <= 48) return '24-48h';
+  if (hours <= 168) return '< 1 week';
+  return '> 1 week';
+}
+
+function sortProducts(
+  products: ProductRequest[],
+  key: SortKey,
+  dir: SortDir
+): ProductRequest[] {
+  const sorted = [...products].sort((a, b) => {
+    let cmp = 0;
+    switch (key) {
+      case 'name':
+        cmp = a.name.localeCompare(b.name);
+        break;
+      case 'type':
+        cmp = findFoodType(a).localeCompare(findFoodType(b));
+        break;
+      case 'quantity':
+        cmp = a.quantity - b.quantity;
+        break;
+      case 'status':
+        cmp = a.status.localeCompare(b.status);
+        break;
+      case 'posted':
+        cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        break;
+      case 'claimSpeed':
+        cmp = getClaimHours(a) - getClaimHours(b);
+        break;
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+  return sorted;
+}
+
+// ── Sparkline: tiny area chart for stat cards ──
+function Sparkline({ data, color }: { data: number[]; color: string }) {
+  if (data.length < 2) return null;
+  const chartData = data.map((v, i) => ({ v, i }));
+  return (
+    <div className='h-8 w-20'>
+      <ResponsiveContainer width='100%' height='100%'>
+        <AreaChart
+          data={chartData}
+          margin={{ top: 2, right: 0, bottom: 0, left: 0 }}
+        >
+          <defs>
+            <linearGradient
+              id={`spark-${color.replace('#', '')}`}
+              x1='0'
+              y1='0'
+              x2='0'
+              y2='1'
+            >
+              <stop offset='0%' stopColor={color} stopOpacity={0.3} />
+              <stop offset='100%' stopColor={color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <Area
+            type='monotone'
+            dataKey='v'
+            stroke={color}
+            strokeWidth={1.5}
+            fill={`url(#spark-${color.replace('#', '')})`}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ── Build weekly buckets for sparkline data ──
+function buildWeeklyBuckets(
+  products: ProductRequest[],
+  weeks: number = 8
+): Date[] {
+  const buckets: Date[] = [];
+  const now = new Date();
+  for (let i = weeks - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i * 7);
+    d.setHours(0, 0, 0, 0);
+    buckets.push(d);
+  }
+  return buckets;
+}
+
+function weeklyCountSpark(products: ProductRequest[]): number[] {
+  const buckets = buildWeeklyBuckets(products);
+  return buckets.map((weekStart, i) => {
+    const weekEnd =
+      i < buckets.length - 1
+        ? buckets[i + 1]
+        : new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+    return products.filter((p) => {
+      const d = new Date(p.createdAt);
+      return d >= weekStart && d < weekEnd;
+    }).length;
+  });
+}
+
+function weeklyQtySpark(products: ProductRequest[]): number[] {
+  const buckets = buildWeeklyBuckets(products);
+  return buckets.map((weekStart, i) => {
+    const weekEnd =
+      i < buckets.length - 1
+        ? buckets[i + 1]
+        : new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+    return products
+      .filter((p) => {
+        const d = new Date(p.createdAt);
+        return d >= weekStart && d < weekEnd;
+      })
+      .reduce((sum, p) => sum + p.quantity, 0);
+  });
+}
+
+// ── Sortable table header ──
+function SortableHeader({
+  label,
+  sortKey,
+  currentKey,
+  currentDir,
+  onSort,
+}: {
+  label: string;
+  sortKey: SortKey;
+  currentKey: SortKey;
+  currentDir: SortDir;
+  onSort: (_key: SortKey) => void;
+}) {
+  const isActive = currentKey === sortKey;
+  return (
+    <th
+      onClick={() => onSort(sortKey)}
+      className='cursor-pointer select-none px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-slate-500 transition-colors hover:text-slate-800 dark:text-foreground'
+    >
+      <div className='flex items-center gap-1'>
+        {label}
+        <span className='inline-flex flex-col'>
+          {isActive ? (
+            currentDir === 'asc' ? (
+              <ChevronUp className='h-3.5 w-3.5 text-blue-600' />
+            ) : (
+              <ChevronDown className='h-3.5 w-3.5 text-blue-600' />
+            )
+          ) : (
+            <ChevronsUpDown className='h-3.5 w-3.5 text-slate-300' />
+          )}
+        </span>
+      </div>
+    </th>
+  );
+}
+
+// ── Detail view shown when a category tile is clicked ──
+function CategoryDetail({
+  filter,
+  products,
+  onBack,
+}: {
+  filter: Exclude<TileFilter, 'all'>;
+  products: ProductRequest[];
+  onBack: () => void;
+}) {
+  const config = FILTER_CONFIG[filter];
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('posted');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
+
+  const typeBreakdown = useMemo(() => {
+    const counts: Record<string, number> = {};
+    products.forEach((p) => {
+      const type = findFoodType(p);
+      counts[type] = (counts[type] || 0) + 1;
+    });
+    return Object.entries(counts)
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [products]);
+
+  const filteredTableProducts = useMemo(() => {
+    let list = products;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      list = list.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          findFoodType(p).toLowerCase().includes(q)
+      );
+    }
+    return sortProducts(list, sortKey, sortDir);
+  }, [products, searchQuery, sortKey, sortDir]);
+
+  // Summary stats
+  const totalQuantity = products.reduce((sum, p) => sum + p.quantity, 0);
+  const topType = typeBreakdown.length > 0 ? typeBreakdown[0].type : 'N/A';
+  const avgClaimHours = useMemo(() => {
+    if (filter === 'available') return null;
+    const claimed = products.filter((p) =>
+      ['RESERVED', 'PENDING'].includes(p.status)
+    );
+    if (claimed.length === 0) return null;
+    const totalHours = claimed.reduce((sum, p) => {
+      const diffMs =
+        new Date(p.updatedAt).getTime() - new Date(p.createdAt).getTime();
+      return sum + diffMs / (1000 * 60 * 60);
+    }, 0);
+    const avg = totalHours / claimed.length;
+    if (avg < 24) return `${Math.round(avg)}h`;
+    return `${(avg / 24).toFixed(1)}d`;
+  }, [products, filter]);
+
+  // Sparkline data
+  const countSpark = useMemo(() => weeklyCountSpark(products), [products]);
+  const qtySpark = useMemo(() => weeklyQtySpark(products), [products]);
+
+  return (
+    <div className='space-y-5'>
+      {/* Header */}
+      <div className='flex flex-wrap items-center justify-between gap-3'>
+        <div className='flex items-center gap-3'>
+          <button
+            onClick={onBack}
+            className='flex items-center justify-center rounded-lg border border-slate-200 bg-white p-2 text-slate-500 shadow-sm transition-colors hover:bg-slate-50 hover:text-slate-900 dark:border-border dark:bg-card dark:text-muted-foreground dark:hover:bg-secondary dark:hover:text-foreground'
+          >
+            <ArrowLeft className='h-4 w-4' />
+          </button>
+          <div>
+            <h2 className='text-lg font-semibold text-slate-900 dark:text-foreground'>
+              {config.title}
+            </h2>
+            <p className='text-sm text-slate-500 dark:text-muted-foreground'>
+              {products.length} {products.length === 1 ? 'product' : 'products'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Mini stat cards with sparklines */}
+      <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
+        <div className='rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-border dark:bg-card'>
+          <div className='flex items-center gap-2 text-slate-500 dark:text-muted-foreground'>
+            <Package className='h-4 w-4' />
+            <span className='text-xs font-medium uppercase tracking-wide'>
+              Count
+            </span>
+          </div>
+          <div className='mt-1 flex items-end justify-between'>
+            <p className='text-xl font-bold text-slate-900 dark:text-foreground'>
+              {products.length}
+            </p>
+            <Sparkline data={countSpark} color='#3b82f6' />
+          </div>
+        </div>
+        <div className='rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-border dark:bg-card'>
+          <div className='flex items-center gap-2 text-slate-500 dark:text-muted-foreground'>
+            <Scale className='h-4 w-4' />
+            <span className='text-xs font-medium uppercase tracking-wide'>
+              Total Qty
+            </span>
+          </div>
+          <div className='mt-1 flex items-end justify-between'>
+            <p className='text-xl font-bold text-slate-900 dark:text-foreground'>
+              {totalQuantity.toLocaleString()}
+            </p>
+            <Sparkline data={qtySpark} color='#10b981' />
+          </div>
+        </div>
+        <div className='rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-border dark:bg-card'>
+          <div className='flex items-center gap-2 text-slate-500 dark:text-muted-foreground'>
+            <TrendingUp className='h-4 w-4' />
+            <span className='text-xs font-medium uppercase tracking-wide'>
+              Top Type
+            </span>
+          </div>
+          <p className='mt-1 text-xl font-bold text-slate-900 dark:text-foreground'>
+            {topType}
+          </p>
+        </div>
+        {avgClaimHours !== null && (
+          <div className='rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-border dark:bg-card'>
+            <div className='flex items-center gap-2 text-slate-500 dark:text-muted-foreground'>
+              <Clock className='h-4 w-4' />
+              <span className='text-xs font-medium uppercase tracking-wide'>
+                Avg Claim
+              </span>
+            </div>
+            <p className='mt-1 text-xl font-bold text-slate-900 dark:text-foreground'>
+              {avgClaimHours}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Product table */}
+      <div className='rounded-lg border border-slate-200 bg-white shadow-md dark:border-border dark:bg-card'>
+        <div className='flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-border sm:px-6'>
+          <h3 className='font-semibold text-slate-800 dark:text-foreground'>
+            Product List
+          </h3>
+          <div className='relative'>
+            <Search className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 dark:text-muted-foreground' />
+            <input
+              type='text'
+              placeholder='Search products...'
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className='rounded-md border border-slate-200 bg-slate-50 py-1.5 pl-9 pr-3 text-sm text-slate-600 placeholder:text-slate-400 focus:border-blue-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-100 dark:border-border dark:bg-secondary dark:text-muted-foreground dark:placeholder:text-muted-foreground dark:focus:bg-secondary dark:focus:ring-blue-800'
+            />
+          </div>
+        </div>
+        <div className='overflow-x-auto'>
+          <table className='w-full text-left text-sm'>
+            <thead className='border-b border-slate-100 bg-slate-50/60 dark:border-border dark:bg-card/60'>
+              <tr>
+                <SortableHeader
+                  label='Product'
+                  sortKey='name'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label='Type'
+                  sortKey='type'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label='Quantity'
+                  sortKey='quantity'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label='Status'
+                  sortKey='status'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label='Posted'
+                  sortKey='posted'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                {filter !== 'available' && (
+                  <SortableHeader
+                    label='Claim Speed'
+                    sortKey='claimSpeed'
+                    currentKey={sortKey}
+                    currentDir={sortDir}
+                    onSort={handleSort}
+                  />
+                )}
+              </tr>
+            </thead>
+            <tbody className='divide-y divide-slate-100 dark:divide-border'>
+              {filteredTableProducts.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={filter !== 'available' ? 6 : 5}
+                    className='px-4 py-10 text-center text-slate-400 dark:text-muted-foreground'
+                  >
+                    {searchQuery
+                      ? 'No products match your search.'
+                      : 'No products in this category.'}
+                  </td>
+                </tr>
+              ) : (
+                filteredTableProducts.map((p) => {
+                  const hours = getClaimHours(p);
+                  const claimSpeed = getClaimSpeedLabel(hours);
+
+                  return (
+                    <tr
+                      key={p.id}
+                      className='transition-colors hover:bg-slate-50 dark:hover:bg-secondary'
+                    >
+                      <td className='px-4 py-3 font-medium text-slate-900 dark:text-foreground'>
+                        {p.name}
+                      </td>
+                      <td className='px-4 py-3'>
+                        <span className='inline-flex rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-secondary dark:text-muted-foreground'>
+                          {findFoodType(p)}
+                        </span>
+                      </td>
+                      <td className='px-4 py-3 text-slate-600 dark:text-muted-foreground'>
+                        {p.quantity} {p.unit?.toLowerCase()}
+                      </td>
+                      <td className='px-4 py-3'>
+                        <span
+                          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                            p.status === 'AVAILABLE'
+                              ? 'bg-green-50 text-green-700 ring-1 ring-green-200 dark:bg-green-900/40 dark:text-green-400 dark:ring-green-800'
+                              : p.status === 'RESERVED'
+                                ? 'bg-blue-50 text-blue-700 ring-1 ring-blue-200 dark:bg-blue-900/40 dark:text-blue-400 dark:ring-blue-800'
+                                : 'bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-900/40 dark:text-amber-400 dark:ring-amber-800'
+                          }`}
+                        >
+                          {formatStatus(p.status)}
+                        </span>
+                      </td>
+                      <td className='px-4 py-3 text-slate-500 dark:text-muted-foreground'>
+                        {formatDate(p.createdAt)}
+                      </td>
+                      {filter !== 'available' && (
+                        <td className='px-4 py-3'>
+                          <span
+                            className={`inline-flex rounded-md px-2 py-0.5 text-xs font-medium ${
+                              claimSpeed === '< 24h'
+                                ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                                : claimSpeed === '24-48h'
+                                  ? 'bg-sky-50 text-sky-700 dark:bg-sky-900/40 dark:text-sky-400'
+                                  : claimSpeed === '< 1 week'
+                                    ? 'bg-violet-50 text-violet-700 dark:bg-violet-900/40 dark:text-violet-400'
+                                    : 'bg-slate-100 text-slate-600 dark:bg-secondary dark:text-muted-foreground'
+                            }`}
+                          >
+                            {claimSpeed}
+                          </span>
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+        {filteredTableProducts.length > 0 && (
+          <div className='border-t border-slate-100 px-4 py-2.5 text-xs text-slate-400 dark:border-border dark:text-muted-foreground'>
+            Showing {filteredTableProducts.length} of {products.length} products
+          </div>
+        )}
+      </div>
+
+      {/* Bar chart by type */}
+      {typeBreakdown.length > 0 && (
+        <div className='rounded-lg border border-slate-200 bg-white p-4 shadow-md dark:border-border dark:bg-card sm:p-6'>
+          <div className='h-80'>
+            <BarChartComponent
+              title={config.barTitle}
+              data={typeBreakdown}
+              xAxisKey='type'
+              bars={[{ dataKey: 'count', fill: '#94a3b8', name: 'Count' }]}
+              cellColors={typeBreakdown.map(
+                (item) => TYPE_COLORS[item.type] || '#94a3b8'
+              )}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main overview (default view with KPI cards + charts) ──
+const OverviewTab = ({
+  metricsData,
+  loadingMetrics,
+  productRequests,
+}: OverviewTabProps) => {
+  const [activeFilter, setActiveFilter] = useState<TileFilter>('all');
+
+  const filteredProducts = useMemo(
+    () => filterProducts(productRequests, activeFilter),
+    [productRequests, activeFilter]
+  );
+
   if (loadingMetrics || !metricsData) {
     return (
-      <div className='flex items-center justify-center py-20 text-slate-400'>
+      <div className='flex items-center justify-center py-20 text-slate-400 dark:text-muted-foreground'>
         Loading metrics...
       </div>
     );
   }
+
+  const handleTileClick = (filter: TileFilter) => {
+    setActiveFilter(filter);
+  };
 
   const hasStatusData = Object.values(metricsData.statusBreakdown).some(
     (v) => v > 0
@@ -33,13 +637,15 @@ const OverviewTab = ({ metricsData, loadingMetrics }: OverviewTabProps) => {
 
   return (
     <div className='space-y-6'>
-      {/* KPI Cards */}
+      {/* KPI Cards — always visible */}
       <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4'>
         <KPICard
           title='Total Products'
           value={metricsData.totalProducts}
           subtitle='Posted to date'
           info={SUPPLIER_CHART_INFO.totalProducts}
+          active={activeFilter === 'all'}
+          onClick={() => handleTileClick('all')}
           icon={
             <svg
               xmlns='http://www.w3.org/2000/svg'
@@ -62,6 +668,8 @@ const OverviewTab = ({ metricsData, loadingMetrics }: OverviewTabProps) => {
           value={metricsData.statusBreakdown.AVAILABLE}
           subtitle='Currently available'
           info={SUPPLIER_CHART_INFO.available}
+          active={activeFilter === 'available'}
+          onClick={() => handleTileClick('available')}
           icon={
             <svg
               xmlns='http://www.w3.org/2000/svg'
@@ -87,6 +695,8 @@ const OverviewTab = ({ metricsData, loadingMetrics }: OverviewTabProps) => {
           }
           subtitle='Successfully claimed'
           info={SUPPLIER_CHART_INFO.claimed}
+          active={activeFilter === 'claimed'}
+          onClick={() => handleTileClick('claimed')}
           icon={
             <svg
               xmlns='http://www.w3.org/2000/svg'
@@ -109,6 +719,8 @@ const OverviewTab = ({ metricsData, loadingMetrics }: OverviewTabProps) => {
           value={metricsData.claimSpeeds.within24h}
           subtitle='Claimed within 24hrs'
           info={SUPPLIER_CHART_INFO.fastClaims}
+          active={activeFilter === 'fast'}
+          onClick={() => handleTileClick('fast')}
           icon={
             <svg
               xmlns='http://www.w3.org/2000/svg'
@@ -128,107 +740,119 @@ const OverviewTab = ({ metricsData, loadingMetrics }: OverviewTabProps) => {
         />
       </div>
 
-      {/* Charts Grid */}
-      <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
-        {/* Product Status Breakdown */}
-        {hasStatusData && (
-          <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md sm:p-6'>
-            <DonutChart
-              title='Product Status Breakdown'
-              info={SUPPLIER_CHART_INFO.productStatusBreakdown}
-              data={[
-                {
-                  name: 'Available',
-                  value: metricsData.statusBreakdown.AVAILABLE,
-                },
-                {
-                  name: 'Reserved',
-                  value: metricsData.statusBreakdown.RESERVED,
-                },
-                { name: 'Pending', value: metricsData.statusBreakdown.PENDING },
-              ].filter((item) => item.value > 0)}
-              colors={['#10b981', '#3b82f6', '#f59e0b']}
-            />
-          </div>
-        )}
+      {/* Drill-down detail view for a selected category */}
+      {activeFilter !== 'all' && (
+        <CategoryDetail
+          filter={activeFilter}
+          products={filteredProducts}
+          onBack={() => setActiveFilter('all')}
+        />
+      )}
 
-        {/* Claim Speed Analysis */}
-        {hasClaimSpeedData && (
-          <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md sm:p-6'>
-            <BarChartComponent
-              title='Product Claim Speed'
-              info={SUPPLIER_CHART_INFO.claimSpeed}
-              data={[
-                {
-                  timeframe: '< 24h',
-                  count: metricsData.claimSpeeds.within24h,
-                },
-                {
-                  timeframe: '24-48h',
-                  count: metricsData.claimSpeeds.within48h,
-                },
-                {
-                  timeframe: '< 1 week',
-                  count: metricsData.claimSpeeds.within1week,
-                },
-                {
-                  timeframe: '> 1 week',
-                  count: metricsData.claimSpeeds.moreThan1week,
-                },
-              ]}
-              xAxisKey='timeframe'
-              bars={[{ dataKey: 'count', fill: '#8b5cf6', name: 'Products' }]}
-            />
-          </div>
-        )}
+      {/* Default overview charts (only when no category is selected) */}
+      {activeFilter === 'all' && (
+        <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
+          {hasStatusData && (
+            <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md dark:border-border dark:bg-card sm:p-6'>
+              <DonutChart
+                title='Product Status Breakdown'
+                info={SUPPLIER_CHART_INFO.productStatusBreakdown}
+                data={[
+                  {
+                    name: 'Available',
+                    value: metricsData.statusBreakdown.AVAILABLE,
+                  },
+                  {
+                    name: 'Reserved',
+                    value: metricsData.statusBreakdown.RESERVED,
+                  },
+                  {
+                    name: 'Pending',
+                    value: metricsData.statusBreakdown.PENDING,
+                  },
+                ].filter((item) => item.value > 0)}
+                colors={['#10b981', '#3b82f6', '#f59e0b']}
+              />
+            </div>
+          )}
 
-        {/* Product Type Breakdown */}
-        {hasTypeData && (
-          <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md sm:p-6'>
-            <DonutChart
-              title='Product Type Distribution'
-              info={SUPPLIER_CHART_INFO.productTypeDistribution}
-              data={[
-                { name: 'Protein', value: metricsData.typeBreakdown.protein },
-                { name: 'Produce', value: metricsData.typeBreakdown.produce },
-                {
-                  name: 'Shelf Stable',
-                  value: metricsData.typeBreakdown.shelfStable,
-                },
-                {
-                  name: 'Individual Serving',
-                  value: metricsData.typeBreakdown.shelfStableIndividualServing,
-                },
-                {
-                  name: 'Prepared Food',
-                  value: metricsData.typeBreakdown.alreadyPreparedFood,
-                },
-                { name: 'Other', value: metricsData.typeBreakdown.other },
-              ].filter((item) => item.value > 0)}
-            />
-          </div>
-        )}
+          {hasClaimSpeedData && (
+            <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md dark:border-border dark:bg-card sm:p-6'>
+              <BarChartComponent
+                title='Product Claim Speed'
+                info={SUPPLIER_CHART_INFO.claimSpeed}
+                data={[
+                  {
+                    timeframe: '< 24h',
+                    count: metricsData.claimSpeeds.within24h,
+                  },
+                  {
+                    timeframe: '24-48h',
+                    count: metricsData.claimSpeeds.within48h,
+                  },
+                  {
+                    timeframe: '< 1 week',
+                    count: metricsData.claimSpeeds.within1week,
+                  },
+                  {
+                    timeframe: '> 1 week',
+                    count: metricsData.claimSpeeds.moreThan1week,
+                  },
+                ]}
+                xAxisKey='timeframe'
+                bars={[{ dataKey: 'count', fill: '#8b5cf6', name: 'Count' }]}
+                cellColors={['#10b981', '#3b82f6', '#a855f7', '#f59e0b']}
+              />
+            </div>
+          )}
 
-        {/* Monthly Timeline */}
-        {hasTimeline && (
-          <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md sm:p-6'>
-            <AreaChartComponent
-              title='Monthly Impact Timeline'
-              info={SUPPLIER_CHART_INFO.monthlyTimeline}
-              data={metricsData.monthlyTimeline}
-              xAxisKey='month'
-              areas={[
-                {
-                  dataKey: 'count',
-                  stroke: '#3b82f6',
-                  fill: '#93c5fd',
-                  name: 'Products Posted',
-                },
-              ]}
-            />
-          </div>
-        )}
-      </div>
+          {hasTypeData && (
+            <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md dark:border-border dark:bg-card sm:p-6'>
+              <DonutChart
+                title='Product Type Distribution'
+                info={SUPPLIER_CHART_INFO.productTypeDistribution}
+                data={[
+                  { name: 'Protein', value: metricsData.typeBreakdown.protein },
+                  { name: 'Produce', value: metricsData.typeBreakdown.produce },
+                  {
+                    name: 'Shelf Stable',
+                    value: metricsData.typeBreakdown.shelfStable,
+                  },
+                  {
+                    name: 'Individual Serving',
+                    value:
+                      metricsData.typeBreakdown.shelfStableIndividualServing,
+                  },
+                  {
+                    name: 'Prepared Food',
+                    value: metricsData.typeBreakdown.alreadyPreparedFood,
+                  },
+                  { name: 'Other', value: metricsData.typeBreakdown.other },
+                ].filter((item) => item.value > 0)}
+              />
+            </div>
+          )}
+
+          {hasTimeline && (
+            <div className='rounded-lg border border-slate-200 bg-white p-3 shadow-md dark:border-border dark:bg-card sm:p-6'>
+              <AreaChartComponent
+                title='Monthly Impact Timeline'
+                info={SUPPLIER_CHART_INFO.monthlyTimeline}
+                data={metricsData.monthlyTimeline}
+                xAxisKey='month'
+                areas={[
+                  {
+                    dataKey: 'count',
+                    stroke: '#3b82f6',
+                    fill: '#93c5fd',
+                    name: 'Products Posted',
+                  },
+                ]}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/supplier/_components/OverviewTab.tsx
+++ b/src/app/supplier/_components/OverviewTab.tsx
@@ -263,6 +263,16 @@ function SortableHeader({
   return (
     <th
       onClick={() => onSort(sortKey)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSort(sortKey);
+        }
+      }}
+      tabIndex={0}
+      aria-sort={
+        isActive ? (currentDir === 'asc' ? 'ascending' : 'descending') : 'none'
+      }
       className='cursor-pointer select-none px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-slate-500 transition-colors hover:text-slate-800 dark:text-foreground'
     >
       <div className='flex items-center gap-1'>

--- a/src/app/supplier/_components/ProductDetailsInputs.tsx
+++ b/src/app/supplier/_components/ProductDetailsInputs.tsx
@@ -16,6 +16,12 @@ interface ProductDetailsInputsProps {
   formatSnakeCase: (_text: string) => string;
 }
 
+const inputClass = (hasError: boolean) =>
+  `w-full rounded-md border ${hasError ? 'border-red-500' : 'border-slate-200 dark:border-border'} bg-slate-50 dark:bg-secondary px-3 py-2 text-sm text-slate-700 dark:text-muted-foreground shadow-sm focus:border-blue-300 focus:bg-white dark:focus:bg-secondary focus:outline-none focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-800`;
+
+const selectClass =
+  'w-full rounded-md border border-slate-200 dark:border-border bg-slate-50 dark:bg-secondary px-3 py-2 text-sm text-slate-700 dark:text-muted-foreground shadow-sm focus:border-blue-300 focus:bg-white dark:focus:bg-secondary focus:outline-none focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-800';
+
 const ProductDetailsInputs = ({
   formData,
   register,
@@ -27,15 +33,20 @@ const ProductDetailsInputs = ({
 
   return (
     <div className='space-y-6'>
-      <h2 className='mb-4 text-xl font-semibold text-black'>Product Details</h2>
+      <h2 className='mb-4 text-lg font-semibold text-slate-800 dark:text-foreground'>
+        Product Details
+      </h2>
       {formData.productTypes.map((type) => (
-        <div key={type} className='space-y-4 rounded-md border p-4'>
-          <h3 className='text-lg font-medium text-black'>
+        <div
+          key={type}
+          className='space-y-4 rounded-lg border border-slate-200 bg-slate-50/50 p-4 dark:border-border dark:bg-card/50'
+        >
+          <h3 className='text-sm font-semibold text-slate-700 dark:text-muted-foreground'>
             {formatSnakeCase(type)} Details
           </h3>
 
           <div>
-            <label className='mb-2 block text-sm font-medium text-black'>
+            <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
               Item Name
             </label>
             <input
@@ -47,18 +58,18 @@ const ProductDetailsInputs = ({
               name={`productDetails.${type}.name`}
               value={formData.productDetails[type]?.name || ''}
               onChange={(e) => handleProductDetailsChange(e, type)}
-              className={`w-full rounded-md border ${errors?.productDetails?.[type]?.name ? 'border-red-500' : 'border-slate-300'} bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500`}
+              className={inputClass(!!errors?.productDetails?.[type]?.name)}
               placeholder='Enter item name'
             />
             {errors?.productDetails?.[type]?.name && (
-              <span className='text-red-500'>
+              <span className='text-sm text-red-500'>
                 {errors?.productDetails?.[type]?.name.message}
               </span>
             )}
           </div>
 
           <div>
-            <label className='mb-2 block text-sm font-medium text-black'>
+            <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
               Item Description
             </label>
             <textarea
@@ -70,11 +81,13 @@ const ProductDetailsInputs = ({
               value={formData.productDetails[type]?.description || ''}
               onChange={(e) => handleProductDetailsChange(e, type)}
               rows={3}
-              className={`w-full rounded-md border ${errors?.productDetails?.[type]?.description ? 'border-red-500' : 'border-slate-300'} bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500`}
+              className={inputClass(
+                !!errors?.productDetails?.[type]?.description
+              )}
               placeholder='Enter item description'
             />
             {errors?.productDetails?.[type]?.description && (
-              <span className='text-red-500'>
+              <span className='text-sm text-red-500'>
                 {errors?.productDetails?.[type]?.description.message}
               </span>
             )}
@@ -83,14 +96,14 @@ const ProductDetailsInputs = ({
           {type === ItemType.PROTEIN ? (
             <>
               <div>
-                <label className='mb-2 block text-sm font-medium text-black'>
+                <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                   Protein Type
                 </label>
                 <select
                   name={`productDetails.${type}.specifics`}
                   value={formData.productDetails[type]?.specifics || ''}
                   onChange={(e) => handleProductDetailsChange(e, type)}
-                  className='w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+                  className={selectClass}
                 >
                   <option value=''>Select type</option>
                   <option value='beef'>Beef</option>
@@ -99,38 +112,36 @@ const ProductDetailsInputs = ({
                   <option value='other'>Other</option>
                 </select>
               </div>
-              <div className='flex gap-4'>
-                <label className='flex items-center text-black'>
-                  <input
-                    type='radio'
-                    name={`productDetails.${type}.condition`}
-                    value='fresh'
-                    checked={
-                      formData.productDetails[type]?.condition === 'fresh'
-                    }
-                    onChange={(e) => handleProductDetailsChange(e, type)}
-                    className='mr-2'
-                  />
-                  Fresh
-                </label>
-                <label className='flex items-center text-black'>
-                  <input
-                    type='radio'
-                    name={`productDetails.${type}.condition`}
-                    value='frozen'
-                    checked={
-                      formData.productDetails[type]?.condition === 'frozen'
-                    }
-                    onChange={(e) => handleProductDetailsChange(e, type)}
-                    className='mr-2'
-                  />
-                  Frozen
-                </label>
+              <div className='flex gap-2'>
+                {(['fresh', 'frozen'] as const).map((condition) => {
+                  const isSelected =
+                    formData.productDetails[type]?.condition === condition;
+                  return (
+                    <label
+                      key={condition}
+                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2.5 text-sm transition-colors ${
+                        isSelected
+                          ? 'border-blue-300 bg-blue-50 text-blue-700 ring-1 ring-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-400 dark:ring-blue-800'
+                          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-border dark:bg-card dark:text-muted-foreground dark:hover:border-slate-600 dark:hover:bg-secondary'
+                      }`}
+                    >
+                      <input
+                        type='radio'
+                        name={`productDetails.${type}.condition`}
+                        value={condition}
+                        checked={isSelected}
+                        onChange={(e) => handleProductDetailsChange(e, type)}
+                        className='h-4 w-4 border-slate-300 bg-white text-blue-600 focus:ring-blue-200 dark:border-slate-500 dark:bg-secondary'
+                      />
+                      {condition.charAt(0).toUpperCase() + condition.slice(1)}
+                    </label>
+                  );
+                })}
               </div>
             </>
           ) : (
             <div>
-              <label className='mb-2 block text-sm font-medium text-black'>
+              <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                 Specify {formatSnakeCase(type)} Type
               </label>
               <input
@@ -138,7 +149,7 @@ const ProductDetailsInputs = ({
                 name={`productDetails.${type}.specifics`}
                 value={formData.productDetails[type]?.specifics || ''}
                 onChange={(e) => handleProductDetailsChange(e, type)}
-                className='w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+                className={inputClass(false)}
                 placeholder='Enter details...'
               />
             </div>
@@ -146,14 +157,14 @@ const ProductDetailsInputs = ({
 
           <div className='mt-4 grid grid-cols-2 gap-4'>
             <div>
-              <label className='mb-2 block text-sm font-medium text-black'>
+              <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                 Measurement Units
               </label>
               <select
                 name={`productDetails.${type}.units`}
                 value={formData.productDetails[type]?.units || ''}
                 onChange={(e) => handleProductDetailsChange(e, type)}
-                className='w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+                className={selectClass}
               >
                 {Object.values(MeasurementUnit).map((unit) => (
                   <option key={unit} value={unit}>
@@ -163,7 +174,7 @@ const ProductDetailsInputs = ({
               </select>
             </div>
             <div>
-              <label className='mb-2 block text-sm font-medium text-black'>
+              <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                 Quantity
               </label>
               <input
@@ -178,11 +189,13 @@ const ProductDetailsInputs = ({
                 min='0'
                 step='1.00'
                 inputMode='decimal'
-                className={`w-full rounded-md border ${errors?.productDetails?.[type]?.quantity ? 'border-red-500' : 'border-slate-300'} bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                className={inputClass(
+                  !!errors?.productDetails?.[type]?.quantity
+                )}
                 placeholder='Enter quantity'
               />
               {errors?.productDetails?.[type]?.quantity && (
-                <span className='text-red-500'>
+                <span className='text-sm text-red-500'>
                   {errors?.productDetails?.[type]?.quantity.message}
                 </span>
               )}

--- a/src/app/supplier/_components/ProductsTab.tsx
+++ b/src/app/supplier/_components/ProductsTab.tsx
@@ -47,26 +47,26 @@ const ProductsTab = ({
   formatSnakeCase,
 }: ProductsTabProps) => {
   return (
-    <>
-      <div className='mb-8 rounded-lg bg-white p-6 shadow-sm'>
-        <h2 className='mb-6 text-2xl font-semibold text-black'>
+    <div className='space-y-6'>
+      <div className='rounded-lg border border-slate-200 bg-white p-6 shadow-md dark:border-border dark:bg-card'>
+        <h2 className='mb-2 text-xl font-semibold text-slate-900 dark:text-foreground'>
           New Food Pick Up Request
         </h2>
-        <p className='mb-6 text-black'>
+        <p className='mb-6 text-sm text-slate-500 dark:text-muted-foreground'>
           Please fill out all fields to submit a new food pick up request.
         </p>
         <form onSubmit={handleSubmit(onSubmit)} className='space-y-8'>
           {/* Product Info Section */}
-          <fieldset className='rounded-md border p-4'>
-            <legend className='px-2 text-lg font-semibold text-black'>
+          <fieldset className='rounded-lg border border-slate-200 p-4 dark:border-border'>
+            <legend className='px-2 text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-muted-foreground'>
               Product Information
             </legend>
             <div className='space-y-4'>
               <div className='space-y-2'>
-                <label className='block text-sm font-medium text-black'>
+                <label className='block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                   Product Category (Select one or more)
                 </label>
-                <div className='space-y-2'>
+                <div className='grid grid-cols-2 gap-2 sm:grid-cols-3'>
                   {[
                     [ItemType.PROTEIN, 'Protein'],
                     [ItemType.PRODUCE, 'Produce'],
@@ -77,25 +77,35 @@ const ProductsTab = ({
                     ],
                     [ItemType.ALREADY_PREPARED_FOOD, 'Already Prepared Food'],
                     [ItemType.OTHER, 'Other'],
-                  ].map(([value, label]) => (
-                    <label key={value} className='flex items-center text-black'>
-                      <input
-                        type='checkbox'
-                        {...register('productTypes', {
-                          required: 'Please select a category',
-                        })}
-                        name='productTypes'
-                        id='productTypes'
-                        value={value}
-                        checked={formData.productTypes.includes(value)}
-                        onChange={() =>
-                          handleProductTypeToggle(value as ItemType)
-                        }
-                        className='mr-2'
-                      />
-                      {label}
-                    </label>
-                  ))}
+                  ].map(([value, label]) => {
+                    const isChecked = formData.productTypes.includes(value);
+                    return (
+                      <label
+                        key={value}
+                        className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+                          isChecked
+                            ? 'border-blue-300 bg-blue-50 text-blue-700 ring-1 ring-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-400 dark:ring-blue-800'
+                            : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-border dark:bg-card dark:text-muted-foreground dark:hover:border-slate-600 dark:hover:bg-secondary'
+                        }`}
+                      >
+                        <input
+                          type='checkbox'
+                          {...register('productTypes', {
+                            required: 'Please select a category',
+                          })}
+                          name='productTypes'
+                          id='productTypes'
+                          value={value}
+                          checked={isChecked}
+                          onChange={() =>
+                            handleProductTypeToggle(value as ItemType)
+                          }
+                          className='h-4 w-4 rounded border-slate-300 bg-white text-blue-600 focus:ring-blue-200 dark:border-slate-500 dark:bg-secondary'
+                        />
+                        {label}
+                      </label>
+                    );
+                  })}
                 </div>
               </div>
               <ProductDetailsInputs
@@ -106,7 +116,7 @@ const ProductsTab = ({
                 formatSnakeCase={formatSnakeCase}
               />
               {errors.productTypes && (
-                <span className='text-red-500'>
+                <span className='text-sm text-red-500'>
                   {errors.productTypes.message}
                 </span>
               )}
@@ -114,12 +124,12 @@ const ProductsTab = ({
           </fieldset>
 
           {/* Pickup Details Section */}
-          <fieldset className='rounded-md border p-4'>
-            <legend className='px-2 text-lg font-semibold text-black'>
+          <fieldset className='rounded-lg border border-slate-200 p-4 dark:border-border'>
+            <legend className='px-2 text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-muted-foreground'>
               Pickup Details
             </legend>
             <div>
-              <label className='mb-2 block text-sm font-medium text-black'>
+              <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                 Pick Up By
               </label>
               <input
@@ -131,10 +141,10 @@ const ProductsTab = ({
                 value={formData.pickupDate}
                 onChange={handleInputChange}
                 min={new Date().toISOString().split('T')[0]}
-                className={`max-w-md rounded-md border ${errors.pickupDate ? 'border-red-500' : 'border-slate-300'} bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black`}
+                className={`max-w-md rounded-md border ${errors.pickupDate ? 'border-red-500' : 'border-slate-200 dark:border-border'} bg-slate-50 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-100 dark:bg-secondary dark:text-muted-foreground dark:focus:bg-secondary dark:focus:ring-blue-800`}
               />
               {errors.pickupDate && (
-                <span className='block text-red-500'>
+                <span className='block text-sm text-red-500'>
                   {errors.pickupDate.message}
                 </span>
               )}
@@ -142,46 +152,52 @@ const ProductsTab = ({
 
             <div className='mt-6 space-y-4'>
               <div>
-                <label className='mb-2 block text-sm font-medium text-slate-700'>
+                <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                   What is the timeframe the product is available?
                 </label>
-                <div className='space-y-2'>
+                <div className='flex flex-wrap gap-2'>
                   {[
                     { value: 'MORNING', label: '7 AM - 10 AM' },
                     { value: 'MID_DAY', label: '10 AM - 2 PM' },
                     { value: 'AFTERNOON', label: '2 PM - 5 PM' },
-                  ].map(({ value, label }) => (
-                    <div key={value} className='flex items-center'>
-                      <input
-                        type='radio'
-                        {...register('availabilityTimeframe', {
-                          required: 'Please select a timeframe',
-                        })}
-                        id={value}
-                        name='availabilityTimeframe'
-                        value={value}
-                        checked={formData.availabilityTimeframe === value}
-                        onChange={handleInputChange}
-                        className='h-4 w-4 border-slate-300 text-blue-600 focus:ring-blue-500'
-                      />
+                  ].map(({ value, label }) => {
+                    const isSelected = formData.availabilityTimeframe === value;
+                    return (
                       <label
+                        key={value}
                         htmlFor={value}
-                        className='ml-2 text-sm text-slate-700'
+                        className={`flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2.5 text-sm transition-colors ${
+                          isSelected
+                            ? 'border-blue-300 bg-blue-50 text-blue-700 ring-1 ring-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-400 dark:ring-blue-800'
+                            : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-border dark:bg-card dark:text-muted-foreground dark:hover:border-slate-600 dark:hover:bg-secondary'
+                        }`}
                       >
+                        <input
+                          type='radio'
+                          {...register('availabilityTimeframe', {
+                            required: 'Please select a timeframe',
+                          })}
+                          id={value}
+                          name='availabilityTimeframe'
+                          value={value}
+                          checked={isSelected}
+                          onChange={handleInputChange}
+                          className='h-4 w-4 border-slate-300 bg-white text-blue-600 focus:ring-blue-200 dark:border-slate-500 dark:bg-secondary'
+                        />
                         {label}
                       </label>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
                 {errors.availabilityTimeframe && (
-                  <span className='text-red-500'>
+                  <span className='text-sm text-red-500'>
                     {errors.availabilityTimeframe.message}
                   </span>
                 )}
               </div>
 
               <div>
-                <label className='mb-2 block text-sm font-medium text-slate-700'>
+                <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                   Where does the product need to be picked up?
                 </label>
                 <input
@@ -193,12 +209,13 @@ const ProductsTab = ({
                   name='pickupLocation'
                   value={formData.pickupLocation}
                   onChange={handleInputChange}
-                  className={`w-full rounded-md border ${errors.pickupLocation ? 'border-red-500' : 'border-slate-300'} bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black`}
+                  className={`w-full rounded-md border ${errors.pickupLocation ? 'border-red-500' : 'border-slate-200 dark:border-border'} bg-slate-50 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-100 dark:bg-secondary dark:text-muted-foreground dark:focus:bg-secondary dark:focus:ring-blue-800`}
                   placeholder='Enter pickup address'
+                  style={{ colorScheme: 'inherit' }}
                 />
               </div>
               {errors.pickupLocation && (
-                <span className='text-red-500'>
+                <span className='text-sm text-red-500'>
                   {errors.pickupLocation.message}
                 </span>
               )}
@@ -206,13 +223,13 @@ const ProductsTab = ({
           </fieldset>
 
           {/* Contact Info Section */}
-          <fieldset className='rounded-md border p-4'>
-            <legend className='px-2 text-lg font-semibold text-black'>
+          <fieldset className='rounded-lg border border-slate-200 p-4 dark:border-border'>
+            <legend className='px-2 text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-muted-foreground'>
               Contact Information
             </legend>
             <div className='grid grid-cols-1 gap-6 md:grid-cols-2'>
               <div>
-                <label className='mb-2 block text-sm font-medium text-slate-700'>
+                <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                   Main Contact Person&apos;s Name
                 </label>
                 <input
@@ -224,17 +241,17 @@ const ProductsTab = ({
                   name='mainContactName'
                   value={formData.mainContactName}
                   onChange={handleInputChange}
-                  className={`w-full rounded-md border ${errors.mainContactName ? 'border-red-500' : 'border-slate-300'} bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black`}
+                  className={`w-full rounded-md border ${errors.mainContactName ? 'border-red-500' : 'border-slate-200 dark:border-border'} bg-slate-50 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-100 dark:bg-secondary dark:text-muted-foreground dark:focus:bg-secondary dark:focus:ring-blue-800`}
                   placeholder='Enter name'
                 />
                 {errors.mainContactName && (
-                  <span className='text-red-500'>
+                  <span className='text-sm text-red-500'>
                     {errors.mainContactName.message}
                   </span>
                 )}
               </div>
               <div>
-                <label className='mb-2 block text-sm font-medium text-slate-700'>
+                <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                   Main Contact Person&apos;s Phone Number
                 </label>
                 <input
@@ -249,11 +266,11 @@ const ProductsTab = ({
                   maxLength={10}
                   pattern='\d{10}'
                   inputMode='numeric'
-                  className={`w-full rounded-md border ${errors.mainContactNumber ? 'border-red-500' : 'border-slate-300'} bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black`}
+                  className={`w-full rounded-md border ${errors.mainContactNumber ? 'border-red-500' : 'border-slate-200 dark:border-border'} bg-slate-50 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-100 dark:bg-secondary dark:text-muted-foreground dark:focus:bg-secondary dark:focus:ring-blue-800`}
                   placeholder='Enter phone number'
                 />
                 {errors.mainContactNumber && (
-                  <span className='text-red-500'>
+                  <span className='text-sm text-red-500'>
                     {errors.mainContactNumber.message}
                   </span>
                 )}
@@ -262,12 +279,12 @@ const ProductsTab = ({
           </fieldset>
 
           {/* Additional Info Section */}
-          <fieldset className='rounded-md border p-4'>
-            <legend className='px-2 text-lg font-semibold text-black'>
+          <fieldset className='rounded-lg border border-slate-200 p-4 dark:border-border'>
+            <legend className='px-2 text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-muted-foreground'>
               Additional Information
             </legend>
             <div>
-              <label className='mb-2 block text-sm font-medium text-black'>
+              <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                 Pick up instructions or other details
               </label>
               <textarea
@@ -275,7 +292,7 @@ const ProductsTab = ({
                 value={formData.instructions}
                 onChange={handleInputChange}
                 rows={3}
-                className='w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+                className='w-full rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-blue-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-100 dark:border-border dark:bg-secondary dark:text-muted-foreground dark:focus:bg-secondary dark:focus:ring-blue-800'
                 placeholder='Enter instructions...'
               />
             </div>
@@ -284,9 +301,9 @@ const ProductsTab = ({
           <div>
             <button
               type='submit'
-              className='rounded-md bg-yellow-400 px-4 py-2 font-medium text-black hover:bg-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2'
+              className='rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-600 dark:focus:ring-offset-background'
             >
-              Submit
+              Submit Request
             </button>
           </div>
         </form>
@@ -295,7 +312,7 @@ const ProductsTab = ({
         rowData={rowData}
         deleteProductRequest={deleteProductRequest}
       />
-    </>
+    </div>
   );
 };
 

--- a/src/app/supplier/_components/TabNav.tsx
+++ b/src/app/supplier/_components/TabNav.tsx
@@ -8,7 +8,7 @@ interface TabNavProps {
 
 const TabNav = ({ activeTab, setActiveTab, productCount }: TabNavProps) => {
   return (
-    <div className='mb-8 flex gap-2 border-b border-slate-200'>
+    <div className='mb-8 flex gap-2 border-b border-slate-200 dark:border-border'>
       {(
         [
           { key: 'overview', label: 'Overview' },
@@ -20,8 +20,8 @@ const TabNav = ({ activeTab, setActiveTab, productCount }: TabNavProps) => {
           onClick={() => setActiveTab(key)}
           className={`px-5 py-3 text-sm font-semibold transition-colors ${
             activeTab === key
-              ? 'border-b-2 border-blue-600 text-blue-600'
-              : 'text-slate-500 hover:text-slate-800'
+              ? 'border-b-2 border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
+              : 'text-slate-500 hover:text-slate-800 dark:text-muted-foreground dark:hover:text-foreground'
           }`}
         >
           {label}

--- a/src/app/supplier/page.tsx
+++ b/src/app/supplier/page.tsx
@@ -55,10 +55,12 @@ const SupplierDashboard = () => {
   }, [status]);
 
   return (
-    <div className='light min-h-screen bg-gray-50'>
-      <header className='bg-white shadow-sm'>
+    <div className='min-h-screen bg-slate-50 dark:bg-background'>
+      <header className='border-b border-slate-200 bg-white dark:border-border dark:bg-card'>
         <div className='mx-auto flex max-w-7xl items-center justify-between px-4 py-4'>
-          <div className='text-xl font-semibold text-black'>MAFC</div>
+          <div className='text-xl font-semibold text-slate-900 dark:text-foreground'>
+            MAFC
+          </div>
         </div>
       </header>
 
@@ -73,6 +75,7 @@ const SupplierDashboard = () => {
           <OverviewTab
             metricsData={metricsData}
             loadingMetrics={loadingMetrics}
+            productRequests={productRequests}
           />
         )}
 

--- a/src/components/Supplier/CopyRequestForm.tsx
+++ b/src/components/Supplier/CopyRequestForm.tsx
@@ -14,6 +14,12 @@ interface FormData {
   availabilityTimeframe: string;
 }
 
+const inputClass =
+  'w-full rounded-md border border-slate-200 dark:border-border bg-slate-50 dark:bg-secondary px-3 py-2 text-sm text-slate-700 dark:text-muted-foreground shadow-sm focus:border-blue-300 focus:bg-white dark:focus:bg-secondary focus:outline-none focus:ring-2 focus:ring-blue-100 dark:focus:ring-blue-800';
+
+const readonlyClass =
+  'w-full rounded-md border border-slate-200 dark:border-border bg-slate-100 dark:bg-secondary/50 px-3 py-2 text-sm text-slate-500 dark:text-muted-foreground shadow-sm';
+
 export const CopyRequestForm: React.FC<CopyRequestFormProps> = ({
   productInfo,
   showCopyRequestForm,
@@ -121,84 +127,90 @@ export const CopyRequestForm: React.FC<CopyRequestFormProps> = ({
   return (
     <div>
       <div
-        className='relative z-10'
+        className='relative z-50'
         aria-labelledby='modal-title'
         role='dialog'
         aria-modal='true'
       >
         <div
-          className='fixed inset-0 bg-gray-500/75 transition-opacity'
+          className='fixed inset-0 z-50 bg-black/50 transition-opacity'
           aria-hidden='true'
         ></div>
-        <div className='fixed inset-0 z-10 w-screen overflow-y-auto'>
+        <div className='fixed inset-0 z-50 w-screen overflow-y-auto'>
           <div className='flex min-h-full items-center justify-center p-4 text-center sm:items-center sm:p-0'>
-            <div className='relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg'>
-              <div className='bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4'>
+            <div className='relative transform overflow-hidden rounded-lg border border-slate-200 bg-white text-left shadow-xl transition-all dark:border-border dark:bg-card sm:my-8 sm:w-full sm:max-w-lg'>
+              <div className='px-4 pb-4 pt-5 sm:p-6 sm:pb-4'>
                 <div>
-                  <div className='mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left'>
-                    <h2 className='mb-6 text-2xl font-semibold text-black'></h2>
-                    <p className='mb-6 text-black'>
+                  <div className='mt-3 sm:ml-4 sm:mt-0'>
+                    <h2 className='mb-2 text-lg font-semibold text-slate-900 dark:text-foreground'>
+                      Copy Pickup Request
+                    </h2>
+                    <p className='mb-6 text-sm text-slate-500 dark:text-muted-foreground'>
                       Please provide new pickup details for the food pick up
                       request you want to copy.
                     </p>
-                    <form onSubmit={handleSubmit} className='space-y-8'>
-                      <div className='mt-2'>
-                        <fieldset className='mt-4 rounded-md border p-4'>
-                          <legend className='px-2 text-lg font-semibold text-black'>
-                            Product Information
-                          </legend>
-                          <div className='space-y-4'>
-                            <div className='space-y-2'>
-                              <label className='block text-sm font-medium text-black'>
-                                Product Category
-                              </label>
-                              <input
-                                type='text'
-                                name='productCategory'
-                                className='w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black'
-                                readOnly
-                                value={productCategory}
-                              />
-                              <label className='block text-sm font-medium text-black'>
-                                Item Name
-                              </label>
-                              <input
-                                type='text'
-                                name='name'
-                                className='w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black'
-                                readOnly
-                                value={productInfo.name}
-                              />
-                              <label className='block text-sm font-medium text-black'>
-                                Item Description
-                              </label>
-                              <input
-                                type='text'
-                                name='description'
-                                className='w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black'
-                                readOnly
-                                value={productInfo.description}
-                              />
-                              <label className='block text-sm font-medium text-black'>
-                                Quantity
-                              </label>
-                              <input
-                                type='text'
-                                name='mainContactName'
-                                className='w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black'
-                                readOnly
-                                value={`${productInfo.quantity} ${productInfo.unit}`}
-                              />
-                            </div>
-                          </div>
-                        </fieldset>
-
-                        <fieldset className='mt-4 rounded-md border p-4'>
-                          <legend className='px-2 text-lg font-semibold text-black'>
-                            Pickup Details
-                          </legend>
+                    <form onSubmit={handleSubmit} className='space-y-6'>
+                      {/* Product info (read-only) */}
+                      <fieldset className='rounded-lg border border-slate-200 p-4 dark:border-border'>
+                        <legend className='px-2 text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-muted-foreground'>
+                          Product Information
+                        </legend>
+                        <div className='space-y-3'>
                           <div>
-                            <label className='mb-2 block text-sm font-medium text-black'>
+                            <label className='mb-1 block text-xs font-medium text-slate-500 dark:text-muted-foreground'>
+                              Product Category
+                            </label>
+                            <input
+                              type='text'
+                              readOnly
+                              value={productCategory}
+                              className={readonlyClass}
+                            />
+                          </div>
+                          <div>
+                            <label className='mb-1 block text-xs font-medium text-slate-500 dark:text-muted-foreground'>
+                              Item Name
+                            </label>
+                            <input
+                              type='text'
+                              readOnly
+                              value={productInfo.name}
+                              className={readonlyClass}
+                            />
+                          </div>
+                          <div>
+                            <label className='mb-1 block text-xs font-medium text-slate-500 dark:text-muted-foreground'>
+                              Description
+                            </label>
+                            <input
+                              type='text'
+                              readOnly
+                              value={productInfo.description}
+                              className={readonlyClass}
+                            />
+                          </div>
+                          <div>
+                            <label className='mb-1 block text-xs font-medium text-slate-500 dark:text-muted-foreground'>
+                              Quantity
+                            </label>
+                            <input
+                              type='text'
+                              readOnly
+                              value={`${productInfo.quantity} ${productInfo.unit}`}
+                              className={readonlyClass}
+                            />
+                          </div>
+                        </div>
+                      </fieldset>
+
+                      {/* Pickup details (editable) */}
+                      <fieldset className='rounded-lg border border-slate-200 p-4 dark:border-border'>
+                        <legend className='px-2 text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-muted-foreground'>
+                          Pickup Details
+                        </legend>
+                        <div className='space-y-4'>
+                          <div>
+                            <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
                               Pick Up By
                             </label>
                             <input
@@ -207,138 +219,108 @@ export const CopyRequestForm: React.FC<CopyRequestFormProps> = ({
                               value={formData.pickupDate}
                               onChange={handleInputChange}
                               min={new Date().toISOString().split('T')[0]}
-                              className='max-w-md rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black'
+                              className={inputClass}
                             />
                           </div>
 
-                          <div className='mt-6 space-y-4'>
-                            <div>
-                              <label className='mb-2 block text-sm font-medium text-slate-700'>
-                                What is the timeframe the product is available?
-                              </label>
-                              <div className='space-y-2'>
-                                <div className='flex items-center'>
-                                  <input
-                                    type='radio'
-                                    id='MORNING'
-                                    name='availabilityTimeframe'
-                                    value='MORNING'
-                                    checked={
-                                      formData.availabilityTimeframe ===
-                                      'MORNING'
-                                    }
-                                    onChange={handleInputChange}
-                                    className='h-4 w-4 border-slate-300 text-blue-600 focus:ring-blue-500'
-                                  />
+                          <div>
+                            <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
+                              Timeframe
+                            </label>
+                            <div className='flex flex-wrap gap-2'>
+                              {[
+                                { value: 'MORNING', label: '7 AM - 10 AM' },
+                                { value: 'MID_DAY', label: '10 AM - 2 PM' },
+                                { value: 'AFTERNOON', label: '2 PM - 5 PM' },
+                              ].map(({ value, label }) => {
+                                const isSelected =
+                                  formData.availabilityTimeframe === value;
+                                return (
                                   <label
-                                    htmlFor='MORNING'
-                                    className='ml-2 text-sm text-slate-700'
+                                    key={value}
+                                    htmlFor={`copy-${value}`}
+                                    className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                                      isSelected
+                                        ? 'border-blue-300 bg-blue-50 text-blue-700 ring-1 ring-blue-200 dark:border-blue-600 dark:bg-blue-900/40 dark:text-blue-400 dark:ring-blue-800'
+                                        : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-border dark:bg-card dark:text-muted-foreground dark:hover:border-slate-600 dark:hover:bg-secondary'
+                                    }`}
                                   >
-                                    7 AM - 10 AM
+                                    <input
+                                      type='radio'
+                                      id={`copy-${value}`}
+                                      name='availabilityTimeframe'
+                                      value={value}
+                                      checked={isSelected}
+                                      onChange={handleInputChange}
+                                      className='h-4 w-4 border-slate-300 bg-white text-blue-600 focus:ring-blue-200 dark:border-slate-500 dark:bg-secondary'
+                                    />
+                                    {label}
                                   </label>
-                                </div>
-                                <div className='flex items-center'>
-                                  <input
-                                    type='radio'
-                                    id='MID_DAY'
-                                    name='availabilityTimeframe'
-                                    value='MID_DAY'
-                                    checked={
-                                      formData.availabilityTimeframe ===
-                                      'MID_DAY'
-                                    }
-                                    onChange={handleInputChange}
-                                    className='h-4 w-4 border-slate-300 text-blue-600 focus:ring-blue-500'
-                                  />
-                                  <label
-                                    htmlFor='MID_DAY'
-                                    className='ml-2 text-sm text-slate-700'
-                                  >
-                                    10 AM - 2 PM
-                                  </label>
-                                </div>
-                                <div className='flex items-center'>
-                                  <input
-                                    type='radio'
-                                    id='AFTERNOON'
-                                    name='availabilityTimeframe'
-                                    value='AFTERNOON'
-                                    checked={
-                                      formData.availabilityTimeframe ===
-                                      'AFTERNOON'
-                                    }
-                                    onChange={handleInputChange}
-                                    className='h-4 w-4 border-slate-300 text-blue-600 focus:ring-blue-500'
-                                  />
-                                  <label
-                                    htmlFor='AFTERNOON'
-                                    className='ml-2 text-sm text-slate-700'
-                                  >
-                                    2 PM - 5 PM
-                                  </label>
-                                </div>
-                              </div>
-                            </div>
-
-                            <div>
-                              <label className='mb-2 block text-sm font-medium text-slate-700'>
-                                Where does the product need to be picked up?
-                              </label>
-                              <input
-                                type='text'
-                                name='pickupLocation'
-                                value={formData.pickupLocation}
-                                onChange={handleInputChange}
-                                className='w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black'
-                                placeholder='Enter pickup address'
-                              />
+                                );
+                              })}
                             </div>
                           </div>
-                        </fieldset>
 
-                        <fieldset className='mt-4 rounded-md border p-4'>
-                          <legend className='px-2 text-lg font-semibold text-black'>
-                            Contact Information
-                          </legend>
+                          <div>
+                            <label className='mb-2 block text-sm font-medium text-slate-700 dark:text-muted-foreground'>
+                              Pickup Location
+                            </label>
+                            <input
+                              type='text'
+                              name='pickupLocation'
+                              value={formData.pickupLocation}
+                              onChange={handleInputChange}
+                              className={inputClass}
+                              placeholder='Enter pickup address'
+                            />
+                          </div>
+                        </div>
+                      </fieldset>
 
-                          <label className='mb-2 block text-sm font-medium text-slate-700'>
-                            Main Contact Person&apos;s Name
-                          </label>
-                          <input
-                            type='text'
-                            name='mainContactName'
-                            readOnly
-                            value={productInfo.pickupInfo.contactName}
-                            className='w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 dark:text-black'
-                          />
+                      {/* Contact info (read-only) */}
+                      <fieldset className='rounded-lg border border-slate-200 p-4 dark:border-border'>
+                        <legend className='px-2 text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-muted-foreground'>
+                          Contact Information
+                        </legend>
+                        <div className='space-y-3'>
+                          <div>
+                            <label className='mb-1 block text-xs font-medium text-slate-500 dark:text-muted-foreground'>
+                              Contact Name
+                            </label>
+                            <input
+                              type='text'
+                              readOnly
+                              value={productInfo.pickupInfo?.contactName}
+                              className={readonlyClass}
+                            />
+                          </div>
+                          <div>
+                            <label className='mb-1 block text-xs font-medium text-slate-500 dark:text-muted-foreground'>
+                              Contact Phone
+                            </label>
+                            <input
+                              type='tel'
+                              readOnly
+                              value={productInfo.pickupInfo?.contactPhone}
+                              className={readonlyClass}
+                            />
+                          </div>
+                        </div>
+                      </fieldset>
 
-                          <label className='mb-2 block text-sm font-medium text-slate-700'>
-                            Main Contact Person&apos;s Phone Number
-                          </label>
-                          <input
-                            type='tel'
-                            name='mainContactNumber'
-                            readOnly
-                            value={productInfo.pickupInfo.contactPhone}
-                            maxLength={10}
-                            pattern='\d{10}'
-                            inputMode='numeric'
-                            className='w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-black shadow-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400'
-                          />
-                        </fieldset>
-                      </div>
-                      <div className='mt-4 flex justify-between'>
+                      <div className='flex justify-between'>
                         <button
-                          className='bg-gray-50 px-4 py-2'
+                          type='button'
+                          className='rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-border dark:bg-secondary dark:text-muted-foreground dark:hover:bg-secondary'
                           onClick={closeRequestForm}
                         >
                           Cancel
                         </button>
                         <button
-                          className='bg-green-800 px-4 py-2 text-white'
+                          className='rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600'
                           type='submit'
                         >
-                          Save
+                          Save Copy
                         </button>
                         <FormSuccessPopup
                           openPopup={showSuccessMessage}

--- a/src/components/Supplier/DeletionConfirmationPopup.tsx
+++ b/src/components/Supplier/DeletionConfirmationPopup.tsx
@@ -16,43 +16,43 @@ export const DeletionConfirmationPopup: React.FC<DeletionConfirmationProps> = ({
   return (
     <div>
       <div
-        className='relative z-10'
+        className='relative z-50'
         aria-labelledby='modal-title'
         role='dialog'
         aria-modal='true'
       >
         <div
-          className='fixed inset-0 bg-gray-500/75 transition-opacity'
+          className='fixed inset-0 z-50 bg-black/50 transition-opacity'
           aria-hidden='true'
         ></div>
-        <div className='fixed inset-0 z-10 w-screen overflow-y-auto'>
+        <div className='fixed inset-0 z-50 w-screen overflow-y-auto'>
           <div className='flex min-h-full items-center justify-center p-4 text-center sm:items-center sm:p-0'>
-            <div className='relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg'>
-              <div className='bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4'>
+            <div className='relative transform overflow-hidden rounded-lg border border-slate-200 bg-white text-left shadow-xl transition-all dark:border-border dark:bg-card sm:my-8 sm:w-full sm:max-w-lg'>
+              <div className='px-4 pb-4 pt-5 sm:p-6 sm:pb-4'>
                 <div className='sm:flex sm:items-start'>
-                  <div className='mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left'>
+                  <div className='mt-3 w-full text-center sm:ml-4 sm:mt-0 sm:text-left'>
                     <h3
-                      className='text-center text-base font-bold text-red-400'
+                      className='text-center text-base font-bold text-red-500 dark:text-red-400'
                       id='modal-title'
                     >
                       Delete Pickup Request
                     </h3>
-                    <hr className='my-4 border-t border-gray-300' />
+                    <hr className='my-4 border-t border-slate-200 dark:border-border' />
                     <div className='mt-2'>
-                      <p className='text-center text-sm text-gray-500'>
+                      <p className='text-center text-sm text-slate-500 dark:text-muted-foreground'>
                         Are you sure you want to delete this pickup request?
                         This action cannot be undone.
                       </p>
                     </div>
-                    <div className='flex justify-between'>
+                    <div className='mt-6 flex justify-between'>
                       <button
-                        className='bg-gray-50 px-4 py-2'
+                        className='rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 dark:border-border dark:bg-secondary dark:text-muted-foreground dark:hover:bg-secondary'
                         onClick={closePopup}
                       >
                         Cancel
                       </button>
                       <button
-                        className='bg-red-400 px-4 py-2 text-white'
+                        className='rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700'
                         onClick={() => {
                           deleteProductRequest(foodId);
                           closePopup();

--- a/src/components/Supplier/PickupRequestTable.tsx
+++ b/src/components/Supplier/PickupRequestTable.tsx
@@ -2,141 +2,247 @@
 
 import { useMemo, useState } from 'react';
 import {
-  Bookmark,
-  AlignLeft,
-  CircleChevronDownIcon,
   Trash2,
   Copy,
+  Search,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
 } from 'lucide-react';
-import CustomColumnHeader from './CustomColumnHeader';
-import { AgGridReact } from 'ag-grid-react';
-import {
-  AllCommunityModule,
-  ModuleRegistry,
-  type ColDef,
-  themeAlpine,
-  colorSchemeDark,
-} from 'ag-grid-community';
-import { useIsDarkTheme } from '@/hooks/use-is-dark-theme';
 import { DeletionConfirmationPopup } from '@/components/Supplier/DeletionConfirmationPopup';
 import { CopyRequestForm } from '@/components/Supplier/CopyRequestForm';
-// Register all Community features
-ModuleRegistry.registerModules([AllCommunityModule]);
+import { SupplierRowData } from '@/app/supplier/_types';
 
-const defaultColDef: ColDef = {
-  sortable: true,
-  editable: true,
-};
+type SortKey = 'foodName' | 'foodType' | 'foodStatus' | 'foodClaimer';
+type SortDir = 'asc' | 'desc';
+
+function SortableHeader({
+  label,
+  sortKey,
+  currentKey,
+  currentDir,
+  onSort,
+}: {
+  label: string;
+  sortKey: SortKey;
+  currentKey: SortKey;
+  currentDir: SortDir;
+  onSort: (_key: SortKey) => void;
+}) {
+  const isActive = currentKey === sortKey;
+  return (
+    <th
+      onClick={() => onSort(sortKey)}
+      className='cursor-pointer select-none px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-slate-500 transition-colors hover:text-slate-800 dark:text-muted-foreground dark:hover:text-foreground'
+    >
+      <div className='flex items-center gap-1'>
+        {label}
+        <span className='inline-flex flex-col'>
+          {isActive ? (
+            currentDir === 'asc' ? (
+              <ChevronUp className='h-3.5 w-3.5 text-blue-600' />
+            ) : (
+              <ChevronDown className='h-3.5 w-3.5 text-blue-600' />
+            )
+          ) : (
+            <ChevronsUpDown className='h-3.5 w-3.5 text-slate-300' />
+          )}
+        </span>
+      </div>
+    </th>
+  );
+}
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function PickupRequestTable({
   rowData,
   deleteProductRequest,
 }: {
-  rowData: any[];
+  rowData: SupplierRowData[];
   deleteProductRequest: (_prodId: string) => void;
 }) {
-  const isDarkTheme = useIsDarkTheme();
-
-  const agGridTheme = useMemo(
-    () => (isDarkTheme ? themeAlpine.withPart(colorSchemeDark) : themeAlpine),
-    [isDarkTheme]
-  );
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [showCopyRequestForm, setShowCopyRequestForm] = useState(false);
   const [foodId, setFoodId] = useState('');
   const [foodInfo, setFoodInfo] = useState({});
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('foodName');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('asc');
+    }
+  };
 
   const confirmDeletion = (prodId: string) => {
     setShowDeleteConfirmation(true);
     setFoodId(prodId);
   };
 
-  const duplicateRequest = (
-    prodInfo: {} // eslint-disable-line @typescript-eslint/no-empty-object-type
-  ) => {
+  const duplicateRequest = (prodInfo: any) => {
     setShowCopyRequestForm(true);
     setFoodInfo(prodInfo);
   };
 
-  const columnDefs: ColDef[] = [
-    {
-      field: 'foodName',
-      headerName: 'Food Item',
-      editable: false,
-      headerComponent: CustomColumnHeader,
-      headerComponentParams: { icon: Bookmark },
-    },
-    {
-      field: 'foodType',
-      headerName: 'Type',
-      editable: false,
-      headerComponent: CustomColumnHeader,
-      headerComponentParams: { icon: AlignLeft },
-    },
-    {
-      field: 'foodStatus',
-      headerName: 'Status',
-      editable: false,
-      headerComponent: CustomColumnHeader,
-      headerComponentParams: { icon: CircleChevronDownIcon },
-    },
-    {
-      field: 'foodClaimer',
-      headerName: 'Recipient',
-      editable: false,
-      headerComponent: CustomColumnHeader,
-      headerComponentParams: { icon: AlignLeft },
-    },
-    {
-      headerName: 'Action',
-      field: 'foodId',
-      headerComponent: CustomColumnHeader,
-      headerComponentParams: { icon: AlignLeft },
-      editable: false,
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      cellRenderer: (params: any) => {
-        return (
-          <div className='flex gap-4'>
-            <div onClick={() => duplicateRequest(params.data.prod)}>
-              <button className='flex items-center justify-center gap-1'>
-                <Copy className='h-3 w-3' />
-                Copy
-              </button>
-            </div>
-
-            <div onClick={() => confirmDeletion(params.data.foodId)}>
-              <button className='flex items-center justify-center gap-1 text-red-400'>
-                <Trash2 className='h-3 w-3' />
-                Delete
-              </button>
-            </div>
-          </div>
-        );
-      },
-    },
-  ];
+  const filteredAndSorted = useMemo(() => {
+    let list = rowData;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      list = list.filter(
+        (r) =>
+          r.foodName.toLowerCase().includes(q) ||
+          r.foodType.toLowerCase().includes(q) ||
+          r.foodStatus.toLowerCase().includes(q)
+      );
+    }
+    return [...list].sort((a, b) => {
+      const cmp = a[sortKey].localeCompare(b[sortKey]);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [rowData, searchQuery, sortKey, sortDir]);
 
   return (
     <div className='h-full w-full'>
-      <div className='mb-8 rounded-lg bg-white p-6 shadow-sm'>
-        <h2 className='mb-6 text-2xl font-semibold text-black'>
-          Pickup Request History
-        </h2>
+      <div className='rounded-lg border border-slate-200 bg-white shadow-md dark:border-border dark:bg-card'>
+        <div className='flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-border sm:px-6'>
+          <h3 className='text-lg font-semibold text-slate-800 dark:text-foreground'>
+            Pickup Request History
+          </h3>
+          <div className='relative'>
+            <Search className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
+            <input
+              type='text'
+              placeholder='Search requests...'
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className='rounded-md border border-slate-200 bg-slate-50 py-1.5 pl-9 pr-3 text-sm text-slate-600 placeholder:text-slate-400 focus:border-blue-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-100 dark:border-border dark:bg-secondary dark:text-muted-foreground dark:placeholder:text-muted-foreground dark:focus:bg-secondary dark:focus:ring-blue-800'
+            />
+          </div>
+        </div>
 
-        <AgGridReact
-          gridOptions={{
-            columnDefs,
-            defaultColDef,
-            domLayout: 'autoHeight',
-            editType: 'fullRow',
-            pagination: true,
-            paginationPageSize: 20,
-          }}
-          theme={agGridTheme}
-          rowData={rowData}
-        />
+        <div className='overflow-x-auto'>
+          <table className='w-full text-left text-sm'>
+            <thead className='border-b border-slate-100 bg-slate-50/60 dark:border-border dark:bg-card/60'>
+              <tr>
+                <SortableHeader
+                  label='Food Item'
+                  sortKey='foodName'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label='Type'
+                  sortKey='foodType'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label='Status'
+                  sortKey='foodStatus'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <SortableHeader
+                  label='Recipient'
+                  sortKey='foodClaimer'
+                  currentKey={sortKey}
+                  currentDir={sortDir}
+                  onSort={handleSort}
+                />
+                <th className='px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-muted-foreground'>
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className='divide-y divide-slate-100 dark:divide-border'>
+              {filteredAndSorted.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className='px-4 py-10 text-center text-slate-400'
+                  >
+                    {searchQuery
+                      ? 'No requests match your search.'
+                      : 'No pickup requests yet.'}
+                  </td>
+                </tr>
+              ) : (
+                filteredAndSorted.map((row) => (
+                  <tr
+                    key={row.foodId}
+                    className='transition-colors hover:bg-slate-50 dark:hover:bg-secondary'
+                  >
+                    <td className='px-4 py-3 font-medium text-slate-900 dark:text-foreground'>
+                      {row.foodName}
+                    </td>
+                    <td className='px-4 py-3'>
+                      <span className='inline-flex rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-secondary dark:text-muted-foreground'>
+                        {row.foodType}
+                      </span>
+                    </td>
+                    <td className='px-4 py-3'>
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                          row.foodStatus === 'AVAILABLE'
+                            ? 'bg-green-50 text-green-700 ring-1 ring-green-200 dark:bg-green-900/40 dark:text-green-400 dark:ring-green-800'
+                            : row.foodStatus === 'RESERVED'
+                              ? 'bg-blue-50 text-blue-700 ring-1 ring-blue-200 dark:bg-blue-900/40 dark:text-blue-400 dark:ring-blue-800'
+                              : 'bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-900/40 dark:text-amber-400 dark:ring-amber-800'
+                        }`}
+                      >
+                        {row.foodStatus}
+                      </span>
+                    </td>
+                    <td className='px-4 py-3'>
+                      <span
+                        className={`inline-flex rounded-md px-2 py-0.5 text-xs font-medium ${
+                          row.foodClaimer === 'Claimed'
+                            ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400'
+                            : 'bg-slate-100 text-slate-500 dark:bg-secondary dark:text-muted-foreground'
+                        }`}
+                      >
+                        {row.foodClaimer}
+                      </span>
+                    </td>
+                    <td className='px-4 py-3'>
+                      <div className='flex items-center gap-3'>
+                        <button
+                          onClick={() => duplicateRequest(row.prod)}
+                          className='flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-muted-foreground dark:hover:bg-secondary dark:hover:text-foreground'
+                        >
+                          <Copy className='h-3.5 w-3.5' />
+                          Copy
+                        </button>
+                        <button
+                          onClick={() => confirmDeletion(row.foodId)}
+                          className='flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-500 transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/30 dark:hover:text-red-400'
+                        >
+                          <Trash2 className='h-3.5 w-3.5' />
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {filteredAndSorted.length > 0 && (
+          <div className='border-t border-slate-100 px-4 py-2.5 text-xs text-slate-400 dark:border-border'>
+            Showing {filteredAndSorted.length} of {rowData.length} requests
+          </div>
+        )}
       </div>
+
       <DeletionConfirmationPopup
         openPopup={showDeleteConfirmation}
         closePopup={() => setShowDeleteConfirmation(false)}

--- a/src/components/Supplier/PickupRequestTable.tsx
+++ b/src/components/Supplier/PickupRequestTable.tsx
@@ -33,6 +33,16 @@ function SortableHeader({
   return (
     <th
       onClick={() => onSort(sortKey)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSort(sortKey);
+        }
+      }}
+      tabIndex={0}
+      aria-sort={
+        isActive ? (currentDir === 'asc' ? 'ascending' : 'descending') : 'none'
+      }
       className='cursor-pointer select-none px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-slate-500 transition-colors hover:text-slate-800 dark:text-muted-foreground dark:hover:text-foreground'
     >
       <div className='flex items-center gap-1'>

--- a/src/components/charts/BarChartComponent.tsx
+++ b/src/components/charts/BarChartComponent.tsx
@@ -7,8 +7,8 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
+  Cell,
 } from 'recharts';
 import { useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -23,6 +23,8 @@ interface BarChartComponentProps {
   info?: string;
   layout?: 'horizontal' | 'vertical';
   itemsPerPage?: number;
+  /** Per-item colors — when provided, each bar gets its own color and a custom legend is rendered */
+  cellColors?: string[];
 }
 
 export function BarChartComponent({
@@ -33,6 +35,7 @@ export function BarChartComponent({
   info,
   layout = 'horizontal',
   itemsPerPage,
+  cellColors,
 }: BarChartComponentProps) {
   const resolvedItemsPerPage = itemsPerPage || 10;
   const [currentPage, setCurrentPage] = useState(1);
@@ -45,6 +48,8 @@ export function BarChartComponent({
   const paginatedData = data.slice(startIndex, endIndex);
   const isPaginated = data.length > resolvedItemsPerPage;
 
+  const useCellColors = cellColors && cellColors.length >= data.length;
+
   return (
     <div className='flex h-full w-full flex-col'>
       <div
@@ -54,7 +59,9 @@ export function BarChartComponent({
       >
         <div className='flex items-center gap-2'>
           {title && (
-            <h3 className='text-lg font-semibold text-slate-800'>{title}</h3>
+            <h3 className='text-lg font-semibold text-slate-800 dark:text-slate-200'>
+              {title}
+            </h3>
           )}
           {info && <ChartInfoTooltip info={info} position='top' />}
         </div>
@@ -102,44 +109,99 @@ export function BarChartComponent({
                 : { bottom: 50, left: 10, right: 10 }
             }
           >
-            <CartesianGrid strokeDasharray='3 3' />
+            <CartesianGrid
+              strokeDasharray='3 3'
+              stroke='rgba(148, 163, 184, 0.2)'
+            />
             {layout === 'horizontal' ? (
               <>
                 <XAxis
                   dataKey={xAxisKey}
-                  tick={{ fontSize: 10 }}
-                  angle={-45}
-                  textAnchor='end'
-                  height={100}
+                  tick={{ fontSize: 12, fill: '#94a3b8' }}
+                  axisLine={{ stroke: '#94a3b8' }}
+                  tickLine={{ stroke: '#94a3b8' }}
                   interval={0}
                 />
-                <YAxis />
+                <YAxis
+                  tick={{ fontSize: 12, fill: '#94a3b8' }}
+                  axisLine={{ stroke: '#94a3b8' }}
+                  tickLine={{ stroke: '#94a3b8' }}
+                  allowDecimals={false}
+                />
               </>
             ) : (
               <>
-                <XAxis type='number' />
+                <XAxis
+                  type='number'
+                  tick={{ fontSize: 12, fill: '#94a3b8' }}
+                  axisLine={{ stroke: '#94a3b8' }}
+                  tickLine={{ stroke: '#94a3b8' }}
+                  allowDecimals={false}
+                />
                 <YAxis
                   dataKey={xAxisKey}
                   type='category'
-                  width={isMobile ? 90 : 150}
-                  tick={{ fontSize: isMobile ? 9 : 11 }}
+                  width={isMobile ? 100 : 160}
+                  tick={{ fontSize: isMobile ? 11 : 13, fill: '#94a3b8' }}
+                  axisLine={{ stroke: '#94a3b8' }}
+                  tickLine={{ stroke: '#94a3b8' }}
                   interval={0}
                 />
               </>
             )}
-            <Tooltip />
-            <Legend />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#1e293b',
+                borderColor: '#334155',
+                borderRadius: '0.5rem',
+                fontSize: '0.85rem',
+                color: '#f1f5f9',
+              }}
+              labelStyle={{
+                fontWeight: 600,
+                marginBottom: '4px',
+                color: '#f1f5f9',
+              }}
+              itemStyle={{ color: '#cbd5e1' }}
+              cursor={{ fill: 'rgba(148, 163, 184, 0.15)' }}
+            />
             {bars.map((bar) => (
               <Bar
                 key={bar.dataKey}
                 dataKey={bar.dataKey}
                 fill={bar.fill}
                 name={bar.name}
-              />
+                radius={[4, 4, 4, 4]}
+              >
+                {useCellColors &&
+                  paginatedData.map((_, idx) => (
+                    <Cell
+                      key={idx}
+                      fill={cellColors[startIndex + idx] || bar.fill}
+                    />
+                  ))}
+              </Bar>
             ))}
           </BarChart>
         </ResponsiveContainer>
       </div>
+
+      {/* Custom legend when using per-item colors */}
+      {useCellColors && (
+        <div className='mt-3 flex flex-wrap justify-center gap-x-4 gap-y-1'>
+          {data.map((item, idx) => (
+            <div key={idx} className='flex items-center gap-1.5'>
+              <span
+                className='inline-block h-3 w-3 rounded-sm'
+                style={{ backgroundColor: cellColors[idx] }}
+              />
+              <span className='text-xs text-slate-500 dark:text-slate-400'>
+                {String(item[xAxisKey])}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/charts/KPICard.tsx
+++ b/src/components/charts/KPICard.tsx
@@ -29,6 +29,14 @@ export function KPICard({
   return (
     <div
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (onClick && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      tabIndex={onClick ? 0 : undefined}
+      role={onClick ? 'button' : undefined}
       className={`rounded-lg border p-4 shadow-md transition-all sm:p-6 ${
         onClick ? 'cursor-pointer' : ''
       } ${

--- a/src/components/charts/KPICard.tsx
+++ b/src/components/charts/KPICard.tsx
@@ -12,6 +12,8 @@ interface KPICardProps {
     value: number;
     label: string;
   };
+  active?: boolean;
+  onClick?: () => void;
 }
 
 export function KPICard({
@@ -21,22 +23,37 @@ export function KPICard({
   icon,
   info,
   trend,
+  active,
+  onClick,
 }: KPICardProps) {
   return (
-    <div className='rounded-lg border border-slate-200 bg-white p-4 shadow-md transition-all hover:shadow-lg sm:p-6'>
+    <div
+      onClick={onClick}
+      className={`rounded-lg border p-4 shadow-md transition-all sm:p-6 ${
+        onClick ? 'cursor-pointer' : ''
+      } ${
+        active
+          ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-200 dark:border-blue-400 dark:bg-blue-950 dark:ring-blue-800'
+          : 'border-slate-200 bg-white hover:shadow-lg dark:border-border dark:bg-card'
+      }`}
+    >
       <div className='flex items-start justify-between'>
         <div className='flex-1'>
           <div className='flex items-center gap-1.5'>
-            <p className='text-sm font-medium text-slate-600'>{title}</p>
+            <p className='text-sm font-medium text-slate-600 dark:text-muted-foreground'>
+              {title}
+            </p>
             {info && (
               <ChartInfoTooltip info={info} position='bottom' size='sm' />
             )}
           </div>
-          <p className='mt-2 text-2xl font-bold text-slate-900 sm:text-3xl'>
+          <p className='mt-2 text-2xl font-bold text-slate-900 dark:text-foreground sm:text-3xl'>
             {value}
           </p>
           {subtitle && (
-            <p className='mt-1 text-sm text-slate-500'>{subtitle}</p>
+            <p className='mt-1 text-sm text-slate-500 dark:text-muted-foreground'>
+              {subtitle}
+            </p>
           )}
           {trend && (
             <div className='mt-2 flex items-center'>


### PR DESCRIPTION
Changed the supplier dashboard to be more interactive and visually consistent with the admin dashboard.

• KPI tiles are now clickable, each opens a detail view with a filtered product table (sortable, searchable) and a color-coded bar chart by food type, plus mini stat cards with sparkline trends
• Restyled the My Products page with new form styling, replaced AG Grid with a custom table, and cleaned up the Copy/Delete modals
• Added full dark mode support across all supplier components using the same CSS theme variables as the admin dashboard so palettes stay in sync

Screenshots below.

<img width="3393" height="1811" alt="Dark Mode" src="https://github.com/user-attachments/assets/c63d54fc-6dac-4086-90d6-207bdfb568b2" />
<img width="3390" height="1827" alt="DM-A" src="https://github.com/user-attachments/assets/adabe431-f6af-497a-a563-0d5053205023" />
<img width="3141" height="1998" alt="DM-CP" src="https://github.com/user-attachments/assets/4621cc5e-a578-4d9e-9853-847d0651be21" />
<img width="3348" height="2130" alt="DM-FC" src="https://github.com/user-attachments/assets/e43c37c8-b680-4ccb-a952-35c5def9f02e" />
<img width="3339" height="2135" alt="DM-MP" src="https://github.com/user-attachments/assets/46673aa9-6b8f-45fb-a0df-eb9b8f9ba8f1" />
<img width="3348" height="2090" alt="LM-A" src="https://github.com/user-attachments/assets/011cbac1-26ae-4727-94d8-94847b3ea1c4" />
<img width="3379" height="2119" alt="LM-CP" src="https://github.com/user-attachments/assets/8311299b-2025-40bb-ab6c-a88199b5734a" />
<img width="3381" height="2135" alt="LM-FC" src="https://github.com/user-attachments/assets/726f8df5-a37a-43da-a7bf-d2e895cc19f5" />
<img width="3291" height="2133" alt="LM-MP" src="https://github.com/user-attachments/assets/f5f15f3b-e7c9-4a1f-a2fe-34a13b3aef4d" />
